### PR TITLE
adding Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/tijcolem/nrel_cbci_jenkins_libs 
  
-@Library('cbci_shared_libs') _
+@Library('cbci_shared_libs@urban_opt') _
 
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set
 
-  openstudio_extension_gems()
+  urbanopt_reopt_gem()
     
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/tijcolem/nrel_cbci_jenkins_libs 
  
-@Library('cbci_shared_libs@urban_opt') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set


### PR DESCRIPTION
Adding Jenkins Pipeline. 

The Jenkins file is calling this CI script (below) which is stored in the central repo for Commerical Buildings CI scripts. 

https://github.com/NREL/cbci_jenkins_libs/blob/urban_opt/vars/urbanopt_reopt_gem.groovy
