### PR TITLE
gemspec: loosen dependency to be compatible with latest URBANopt-scenario

### DIFF
--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '~> 2.5.0'
-  
+
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'certified', '~> 1'
   spec.add_dependency 'json_pure', '~> 2'
-  spec.add_dependency 'urbanopt-scenario', '~> 0.3.0'
+  spec.add_dependency 'urbanopt-scenario', '>= 0.3.0'
 end


### PR DESCRIPTION
### Addresses #[issue number here]
Makes gemspec compatible with requirements for urbanopt-scenario 0.4.0 release

### Pull Request Description

updates gemspec

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [ ] This branch is up-to-date with develop
