### PR TITLE
PR template now automatically closes issue on merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-### Addresses #[issue number here]
+### Resolves #[issue number here]
 
 ### Pull Request Description
 
@@ -9,5 +9,5 @@
 - [ ] Unit tests have been added or updated
 - [ ] Documentation has been modified appropriately
 - [ ] All ci tests pass (green)
-- [ ] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
+- [ ] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
 - [ ] This branch is up-to-date with develop


### PR DESCRIPTION
### Pull Request Description

Change the PR template wording so issues will automagically be closed when PRs merge.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop
