### PR TITLE
remove unnecessary require statement

### DIFF
--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -31,7 +31,6 @@
 require 'bundler/setup'
 require 'urbanopt/reporting/default_reports'
 require 'urbanopt/reopt/reopt_logger'
-require 'urbanopt/reopt'
 require 'csv'
 
 module URBANopt # :nodoc:


### PR DESCRIPTION
### Resolves #30 

### Pull Request Description

Removes unnecessary require statement. It wasn't causing any visible problems, but was a strange circular requirement. Now cleaner

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [ISSUE](https://github.com/urbanopt/urbanopt-cli/issues) has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
