### PR TITLE
extend resilience polling

### DIFF
--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -197,7 +197,7 @@ module URBANopt # :nodoc:
         end
 
         elapsed_time = 0
-        max_elapsed_time = 60
+        max_elapsed_time = 60 * 5
         
         request = Net::HTTP::Get.new(uri.request_uri)
         response = make_request(http, request)

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -221,8 +221,10 @@ module URBANopt # :nodoc:
         if response.code == "200"
           return data
         end
-
-        raise "Error from REopt API - #{data['Error']}"
+        
+        @@logger.info("Error from REopt API - #{data['Error']}")
+        return {}
+        
       end
 
       ##


### PR DESCRIPTION
### Resolves #[58]

Extends polling for resilience results
Does not raise an error when resilience stats cannot be returned from the API

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
