### PR TITLE
Update feature_report_adapter.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # URBANopt REopt Gem
 
+## Version 0.5.6
+
+Date range: 3/12/21 - 4/7/21
+* Fixes a bug that shifts REopt Lite timeseries data by 24 hours in **Feature Report** CSV's
+
 ## Version 0.5.5
 
 Date range: 2/8/21 - 3/12/21

--- a/lib/urbanopt/reopt/feature_report_adapter.rb
+++ b/lib/urbanopt/reopt/feature_report_adapter.rb
@@ -448,7 +448,7 @@ module URBANopt # :nodoc:
 
         mod_data = old_data.map.with_index do |x, i|
           if i > 0
-            modrow(x, start_ts + i -2)
+            modrow(x, start_ts + i -1)
           else
             x
           end

--- a/lib/urbanopt/reopt/version.rb
+++ b/lib/urbanopt/reopt/version.rb
@@ -40,6 +40,6 @@
 
 module URBANopt # :nodoc:
   module REopt # :nodoc:
-    VERSION = '0.5.5'.freeze
+    VERSION = '0.5.6'.freeze
   end
 end


### PR DESCRIPTION
### Resolves #76

Solves bug saving issue where REopt Lite results are saved to a Feature Report CSV 

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
