### PR TITLE
Comm sol enhance

### DIFF
--- a/lib/urbanopt/reopt/feature_report_adapter.rb
+++ b/lib/urbanopt/reopt/feature_report_adapter.rb
@@ -101,6 +101,21 @@ module URBANopt # :nodoc:
         # Parse Optional FeatureReport metrics - do not overwrite from assumptions file
         if reopt_inputs[:Scenario][:Site][:roof_squarefeet].nil? && !feature_report.program.roof_area_sqft.nil?
           reopt_inputs[:Scenario][:Site][:roof_squarefeet] = feature_report.program.roof_area_sqft[:available_roof_area_sqft]
+          reopt_assumptions_hash[:Scenario][:Site][:PV].each do |pv|
+
+            # Check for rooftop PV
+            if pv[:location] == 'roof'
+              begin
+                # Check if % roof area is specified
+                if pv[:perc_roof_area]
+                  perc_roof_area = pv[:perc_roof_area]
+                  # Update roof square feet for the site based on % roof area specified
+                  reopt_inputs[:Scenario][:Site][:roof_squarefeet] = (feature_report.program.roof_area_sqft[:available_roof_area_sqft])*perc_roof_area
+                end
+              rescue
+              end
+            end
+          end
         end
 
         if reopt_inputs[:Scenario][:Site][:land_acres].nil? && !feature_report.program.site_area_sqft.nil?

--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -166,7 +166,7 @@ module URBANopt # :nodoc:
       # * +timeseries_csv_path+ - _String_ - Optional. Path to a file at which the new timeseries CSV for the ScenarioReport will be saved.
       #
       # [*return:*] _URBANopt::Scenario::DefaultReports::ScenarioReport_ Returns an updated ScenarioReport
-      def run_scenario_report(scenario_report:, reopt_assumptions_hash: nil, reopt_output_file: nil, timeseries_csv_path: nil, save_name: nil, run_resilience: true)
+      def run_scenario_report(scenario_report:, reopt_assumptions_hash: nil, reopt_output_file: nil, timeseries_csv_path: nil, save_name: nil, run_resilience: true, community_photovoltaic: nil)
         if !reopt_assumptions_hash.nil?
           @scenario_reopt_default_assumptions_hash = reopt_assumptions_hash
         end
@@ -180,7 +180,7 @@ module URBANopt # :nodoc:
         api = URBANopt::REopt::REoptLiteAPI.new(@nrel_developer_key, @localhost)
         adapter = URBANopt::REopt::ScenarioReportAdapter.new
 
-        reopt_input = adapter.reopt_json_from_scenario_report(scenario_report, @scenario_reopt_default_assumptions_hash)
+        reopt_input = adapter.reopt_json_from_scenario_report(scenario_report, @scenario_reopt_default_assumptions_hash, community_photovoltaic)
 
         reopt_output = api.reopt_request(reopt_input, @scenario_reopt_default_output_file)
         if run_resilience

--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -212,7 +212,7 @@ module URBANopt # :nodoc:
       # * +timeseries_csv_path+ - _Array_ - Optional. A array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the feature_reports array.
       #
       # [*return:*] _Array_ Returns an array of updated _URBANopt::Scenario::DefaultReports::FeatureReport_ objects
-      def run_feature_reports(feature_reports:, reopt_assumptions_hashes: [], reopt_output_files: [], timeseries_csv_paths: [], save_names: nil, run_resilience: true, keep_existing_output: false)
+      def run_feature_reports(feature_reports:, reopt_assumptions_hashes: [], reopt_output_files: [], timeseries_csv_paths: [], save_names: nil, run_resilience: true, keep_existing_output: false, groundmount_photovoltaic: nil)
         if !reopt_assumptions_hashes.empty?
           @feature_reports_reopt_default_assumption_hashes = reopt_assumptions_hashes
         end
@@ -244,7 +244,7 @@ module URBANopt # :nodoc:
           # check if we should rerun
           if !(keep_existing_output && output_exists(@feature_reports_reopt_default_output_files[idx]))
             begin
-              reopt_input = feature_adapter.reopt_json_from_feature_report(feature_report, @feature_reports_reopt_default_assumption_hashes[idx])
+              reopt_input = feature_adapter.reopt_json_from_feature_report(feature_report, @feature_reports_reopt_default_assumption_hashes[idx], groundmount_photovoltaic)
               reopt_output = api.reopt_request(reopt_input, @feature_reports_reopt_default_output_files[idx])
               if run_resilience
                 run_uuid = reopt_output['outputs']['Scenario']['run_uuid']
@@ -305,8 +305,8 @@ module URBANopt # :nodoc:
       # * +feature_report_timeseries_csv_paths+ - _Array_ - Optional. An array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
       #
       # [*return:*] _URBANopt::Scenario::DefaultReports::ScenarioReport_ - Returns an updated ScenarioReport
-      def run_scenario_report_features(scenario_report:, reopt_assumptions_hashes: [], reopt_output_files: [], feature_report_timeseries_csv_paths: [], save_names_feature_reports: nil, save_name_scenario_report: nil, run_resilience: true, keep_existing_output: false)
-        new_feature_reports = run_feature_reports(feature_reports: scenario_report.feature_reports, reopt_assumptions_hashes: reopt_assumptions_hashes, reopt_output_files: reopt_output_files, timeseries_csv_paths: feature_report_timeseries_csv_paths, save_names: save_names_feature_reports, run_resilience: run_resilience, keep_existing_output: keep_existing_output)
+      def run_scenario_report_features(scenario_report:, reopt_assumptions_hashes: [], reopt_output_files: [], feature_report_timeseries_csv_paths: [], save_names_feature_reports: nil, save_name_scenario_report: nil, run_resilience: true, keep_existing_output: false, groundmount_photovoltaic: nil)
+        new_feature_reports = run_feature_reports(feature_reports: scenario_report.feature_reports, reopt_assumptions_hashes: reopt_assumptions_hashes, reopt_output_files: reopt_output_files, timeseries_csv_paths: feature_report_timeseries_csv_paths, save_names: save_names_feature_reports, run_resilience: run_resilience, keep_existing_output: keep_existing_output, groundmount_photovoltaic: groundmount_photovoltaic)
         puts("KEEP EXISTING? #{keep_existing_output}")
         # only do this if you have run feature reports
         new_scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new

--- a/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
+++ b/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
@@ -371,6 +371,11 @@
 										"description": "State rebate based on installed capacity",
 										"min": 0
 									},
+									"location": {
+										"default": "roof",
+										"type": "string",
+										"description": "Indicates location of PV. Available options are roof and ground."
+									},
 									"max_kw": {
 										"default": 1000000000.0,
 										"max": 1000000000.0,

--- a/lib/urbanopt/reopt/reopt_schema/reopt_output_schema.json
+++ b/lib/urbanopt/reopt/reopt_schema/reopt_output_schema.json
@@ -142,6 +142,11 @@
                   "PV": {
                     "type": "object",
                     "properties": {
+                      "location": {
+                        "default": "roof",
+                        "type": "string",
+                        "description": "Indicates location of PV. Available options are roof and ground."
+                      },
                       "size_kw": {
                         "type": "float",
                         "description": "Optimal PV system size",

--- a/lib/urbanopt/reopt/scenario_report_adapter.rb
+++ b/lib/urbanopt/reopt/scenario_report_adapter.rb
@@ -230,9 +230,6 @@ module URBANopt # :nodoc:
         end
 
 
-        puts "4HELLO this is scenario report = #{reopt_output['inputs']['Scenario']['Site']['PV'][0]['location']}"
-        puts "4HELLO this is scenario report = #{reopt_output['outputs']['Scenario']['Site']['PV'][0]['pv_name']}"
-        puts "4HELLO this is scenario report = #{reopt_output['inputs']['Scenario']['Site']['PV'][0]['pv_name']}"
         # Update location
         scenario_report.location.latitude_deg = reopt_output['inputs']['Scenario']['Site']['latitude']
         scenario_report.location.longitude_deg = reopt_output['inputs']['Scenario']['Site']['longitude']

--- a/lib/urbanopt/reopt/scenario_report_adapter.rb
+++ b/lib/urbanopt/reopt/scenario_report_adapter.rb
@@ -67,7 +67,7 @@ module URBANopt # :nodoc:
       #
       # [*return:*] _Hash_ - Returns hash formatted for submittal to the \REopt Lite API
       ##
-      def reopt_json_from_scenario_report(scenario_report, reopt_assumptions_json = nil)
+      def reopt_json_from_scenario_report(scenario_report, reopt_assumptions_json = nil, community_photovoltaic)
         name = scenario_report.name.delete ' '
         scenario_id = scenario_report.id.delete ' '
         description = "scenario_report_#{name}_#{scenario_id}"
@@ -122,8 +122,8 @@ module URBANopt # :nodoc:
           reopt_inputs[:Scenario][:Site][:roof_squarefeet] = scenario_report.program.roof_area_sqft[:available_roof_area_sqft]
         end
 
-        if reopt_inputs[:Scenario][:Site][:land_acres].nil? && !scenario_report.program.site_area_sqft.nil?
-          reopt_inputs[:Scenario][:Site][:land_acres] = scenario_report.program.site_area_sqft * 1.0 / 43560 # acres/sqft
+        if reopt_inputs[:Scenario][:Site][:land_acres].nil? && !community_photovoltaic[0][:properties][:footprint_area].nil?
+          reopt_inputs[:Scenario][:Site][:land_acres] = community_photovoltaic[0][:properties][:footprint_area] * 1.0 / 43560 # acres/sqft
         end
 
         if reopt_inputs[:Scenario][:time_steps_per_hour].nil?


### PR DESCRIPTION
### Resolves #91 , #90 

### Pull Request Description

- Uses footprint area of PV system (ground-mount and community solar) from feature file and sets it equal to the land_acres PV area constrain in REopt feature and scenario optimization.
- Adds location of PV system from the reopt_input file and adds it to reopt scenario and feature reports.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
