### PR TITLE
set up actions with coveralls

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,41 @@
+name: nightly_build
+
+on:
+  push:
+  # schedule:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+    # 5 am UTC (11pm MDT the day before) every weekday night in MDT
+    # - cron: '21 5 * * 2-6'
+
+# Cancels an existing job (of the same workflow) if it is still running
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+
+env:
+  # This env var should enforce develop branch of all dependencies
+  FAVOR_LOCAL_GEMS: true
+  GEM_DEVELOPER_KEY: ${{ secrets.GEM_DEVELOPER_KEY }}
+
+jobs:
+  weeknight-tests:
+    # Pinned to `ubuntu-20.04`. When ubuntu-latest adopts 22.04 it would break for us since 22 only supports Ruby 3.1
+    # https://github.com/ruby/setup-ruby#supported-platforms
+    runs-on: ubuntu-20.04
+    container:
+      image: docker://nrel/openstudio:3.4.0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Update gems
+        run: |
+          bundle update
+      - name: Run Rspec
+        run: bundle exec rspec
+      # coveralls action docs: https://github.com/marketplace/actions/coveralls-github-action
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: "./coverage/lcov/urbanopt-reopt-gem.lcov"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,11 +1,11 @@
 name: nightly_build
 
 on:
-  push:
-  # schedule:
+  # push:
+  schedule:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5 am UTC (11pm MDT the day before) every weekday night in MDT
-    # - cron: '21 5 * * 2-6'
+    - cron: '23 5 * * 2-6'
 
 # Cancels an existing job (of the same workflow) if it is still running
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Update gems
         run: |
           bundle update
+          bundle exec certified-update
       - name: Run Rspec
         run: bundle exec rspec
       # coveralls action docs: https://github.com/marketplace/actions/coveralls-github-action

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # URBANopt REopt Gem
 
+[![Coverage Status](https://coveralls.io/repos/github/urbanopt/urbanopt-reopt-gem/badge.svg?branch=github-actions-coveralls)](https://coveralls.io/github/urbanopt/urbanopt-reopt-gem?branch=github-actions-coveralls)
+
 The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt Lite](https://reopt.nrel.gov/tool) decision support platform.
 REopt Lite is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt-v1/](https://developer.nrel.gov/docs/energy-optimization/reopt-v1/) for more detailed information on input parameters and default assumptions.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,16 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 # *********************************************************************************
 
+require 'simplecov'
+require 'simplecov-lcov'
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+# Don't consider the spec folder for test coverage reporting (inside the do/end loop)
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require 'bundler/setup'
 require 'urbanopt/reopt'
 require 'urbanopt/reporting/default_reports'

--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 2.1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'simplecov', '~> 0.18.2'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
 
   spec.add_dependency 'certified', '~> 1'
   spec.add_dependency 'json_pure', '~> 2'


### PR DESCRIPTION
### Resolves #124 

### Pull Request Description

Adds Github action to run all tests via rspec and report coverage via Coveralls. Syntax is copied from geojson-gem.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
