### PR TITLE
Multi pv test fix

### DIFF
--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -83,9 +83,6 @@ module URBANopt # :nodoc:
               @@logger.info("Created directory: #{File.join(fr.directory_name, 'reopt')}")
             end
             @feature_reports_reopt_default_output_files << File.join(fr.directory_name, "reopt/feature_report_#{fr.id}_reopt_run.json")
-          end
-
-          @scenario_report.feature_reports.each do |fr|
             @feature_reports_timeseries_default_output_files << File.join(fr.directory_name, "feature_report_#{fr.id}_timeseries.csv")
           end
         end
@@ -129,7 +126,7 @@ module URBANopt # :nodoc:
           reopt_output_file = File.join(feature_report.directory_name, 'reopt')
         end
         reopt_output = api.reopt_request(reopt_input, reopt_output_file)
-        print("REOPT OUTPUT FILE: #{reopt_output_file}")
+        @@logger.debug("REOpt output file: #{reopt_output_file}")
         if run_resilience
           run_uuid = reopt_output['outputs']['Scenario']['run_uuid']
           if File.directory? reopt_output_file
@@ -160,7 +157,7 @@ module URBANopt # :nodoc:
       #
       # [*return:*] _URBANopt::Scenario::DefaultReports::ScenarioReport_ Returns an updated ScenarioReport
       def run_scenario_report(scenario_report:, reopt_assumptions_hash: nil, reopt_output_file: nil, timeseries_csv_path: nil, save_name: nil, run_resilience: true, community_photovoltaic: nil)
-        puts "run scenario report"
+        puts 'run scenario report'
         @save_assumptions_filepath = false
         if !reopt_assumptions_hash.nil?
           @scenario_reopt_default_assumptions_hash = reopt_assumptions_hash

--- a/spec/tests/urbanopt_reopt_spec.rb
+++ b/spec/tests/urbanopt_reopt_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe URBANopt::REopt do
 
     scenario_report.save 'test__/can_process_multiple_PV'
 
-    reopt_output_file = scenario_report.directory_name / 'reopt' / 'scenario_report_multiPV_reopt_run.json'
+    reopt_output_file = scenario_report.directory_name / 'scenario_report_multiPV_reopt_run.json'
     timeseries_output_file = File.join(scenario_report.directory_name, 'scenario_report_timeseries1.csv')
     reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
@@ -217,7 +217,8 @@ RSpec.describe URBANopt::REopt do
     scenario_report = adapter.update_scenario_report(scenario_report, reopt_output, timeseries_output_file)
     scenario_report.save 'test__/scenario_report_reopt_mulitPV'
 
-    FileUtils.rm_rf('spec/run/example_scenario/reopt')
+    expect(File.exist?(reopt_output_file)).to be true
+
     FileUtils.rm_rf('spec/run/example_scenario/test__')
     FileUtils.rm_rf('spec/run/example_scenario/1/feature_reports')
     FileUtils.rm_rf('spec/run/example_scenario/2/feature_reports')

--- a/spec/tests/urbanopt_reopt_spec.rb
+++ b/spec/tests/urbanopt_reopt_spec.rb
@@ -32,6 +32,7 @@ require_relative '../spec_helper'
 require_relative '../../developer_nrel_key'
 require 'certified'
 require 'fileutils'
+require 'pathname'
 
 RSpec.describe URBANopt::REopt do
   it 'has a version number' do
@@ -162,7 +163,7 @@ RSpec.describe URBANopt::REopt do
     FileUtils.rm_rf('spec/run/example_scenario/1/feature_reports')
   end
 
-  it 'can process multiple PV\'s ' do
+  it "can process multiple PV's" do
     begin
       FileUtils.rm_rf('spec/run/example_scenario/reopt')
       FileUtils.rm_rf('spec/run/example_scenario/test__')
@@ -173,7 +174,7 @@ RSpec.describe URBANopt::REopt do
     end
     scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new
 
-    scenario_report_dir = File.join(File.dirname(__FILE__), '../run/example_scenario')
+    scenario_report_dir = Pathname(__FILE__).dirname.parent / 'run' / 'example_scenario'
     scenario_report.directory_name = scenario_report_dir
 
     (1..2).each do |i|
@@ -196,7 +197,7 @@ RSpec.describe URBANopt::REopt do
 
     scenario_report.save 'test__/can_process_multiple_PV'
 
-    reopt_output_file = File.join(scenario_report.directory_name, 'reopt/scenario_report_multiPV_reopt_run.json')
+    reopt_output_file = scenario_report.directory_name / 'reopt' / 'scenario_report_multiPV_reopt_run.json'
     timeseries_output_file = File.join(scenario_report.directory_name, 'scenario_report_timeseries1.csv')
     reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 


### PR DESCRIPTION
### Resolves #113 

### Pull Request Description

- The multi-PV test was expecting a directory that hadn't been created. The missing dir (among others) and its contents get deleted a few lines below, so I fixed the path to not include that dir.
- Added a check for the file that was missing, which should have been there all along and cause the test to fail.

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
