### PR TITLE
remove "lite" name from reopt

### DIFF
--- a/RDOC_MAIN.md
+++ b/RDOC_MAIN.md
@@ -1,7 +1,7 @@
 # **URBANopt REopt Gem**
 
-The **URBANopt™ REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt Lite](https://reopt.nrel.gov/tool) decision support platform.
-REopt Lite is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The **URBANopt™ REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nrel.gov/tool) decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 See the [example project](https://github.com/urbanopt/urbanopt-example-reopt-project.git) for more infomation about usage of this gem.
 
@@ -31,7 +31,7 @@ Or install it yourself as:
 
 ## Functionality
 
-This gem is used to call the REopt Lite API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
+This gem is used to call the REopt API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
 
 ```
 	"distributed_generation": {
@@ -83,9 +83,9 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 ```
 
-The REopt Lite has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
-<b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt Lite assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
+<b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
 
 
@@ -101,19 +101,19 @@ feature_reports_hash = {} # <insert a Feature Report hash here>
 #Create a Feature Report
 feature_report = URBANopt::Reporting::DefaultReports::FeatureReport.new(feature_reports_hash)
 
-#Specify a file name where REopt Lite results will be written in JSON format
+#Specify a file name where REopt results will be written in JSON format
 reopt_output_file = File.join(feature_report.directory_name, 'feature_report_reopt_run1.json')
 
-#Specify a file name where the new timeseries CSV will be written after REopt Lite has determined cost optimal dispatch
+#Specify a file name where the new timeseries CSV will be written after REopt has determined cost optimal dispatch
 timeseries_output_file = File.join(feature_report.directory_name, 'feature_report_timeseries1.csv')
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor to update the feature's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
 
 ```
@@ -142,13 +142,13 @@ scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new({:dire
   scenario_report.add_feature_report(feature_report)
 end
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
 
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/urbanopt/urbanopt-reopt-gem/badge.svg?branch=develop)](https://coveralls.io/github/urbanopt/urbanopt-reopt-gem?branch=develop)
 [![nightly_build](https://github.com/urbanopt/urbanopt-reopt-gem/actions/workflows/nightly_build.yml/badge.svg)](https://github.com/urbanopt/urbanopt-reopt-gem/actions/workflows/nightly_build.yml)
 
-The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt Lite](https://reopt.nrel.gov/tool) decision support platform.
-REopt Lite is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nrel.gov/tool) decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 See the [example project](https://github.com/urbanopt/urbanopt-example-geojson-reopt-project) for more infomation about usage of this gem.
 
@@ -38,7 +38,7 @@ Or install it yourself as:
 
 ## Functionality
 
-This gem is used to call the REopt Lite API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
+This gem is used to call the REopt API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
 ```
 	"distributed_generation": {
 	      "lcc_us_dollars": 100000000.0,
@@ -88,9 +88,9 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 
 
-The REopt Lite has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
 
-<b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt Lite assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
+<b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
 
 
@@ -106,19 +106,19 @@ feature_reports_hash = {} # <insert a Feature Report hash here>
 #Create a Feature Report
 feature_report = URBANopt::Reporting::DefaultReports::FeatureReport.new(feature_reports_hash)
 
-#Specify a file name where REopt Lite results will be written in JSON format
+#Specify a file name where REopt results will be written in JSON format
 reopt_output_file = File.join(feature_report.directory_name, 'feature_report_reopt_run1.json')
 
-#Specify a file name where the new timeseries CSV will be written after REopt Lite has determined cost optimal dispatch
+#Specify a file name where the new timeseries CSV will be written after REopt has determined cost optimal dispatch
 timeseries_output_file = File.join(feature_report.directory_name, 'feature_report_timeseries1.csv')
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor to update the feature's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
 
 ```
@@ -146,13 +146,13 @@ scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new({:dire
   scenario_report.add_feature_report(feature_report)
 end
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 ### <StaticLink target="\_blank" href="rdoc/">Rdocs</StaticLink>
 
-The **URBANopt<sup>&trade;</sup> REopt Gem** extends a **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the <StaticLink target="\_blank" href="https://reopt.nrel.gov/tool">REopt Lite</StaticLink> decision support platform.
-REopt Lite is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
+The **URBANopt<sup>&trade;</sup> REopt Gem** extends a **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the <StaticLink target="\_blank" href="https://reopt.nrel.gov/tool">REopt</StaticLink> decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
 
 The REopt Gem accomplishes three basic functions (described more below in the _Functionality_ section):
 
@@ -49,7 +49,7 @@ Or install it yourself as:
 
 ## Functionality
 
-This gem is used to call the REopt Lite API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
+This gem is used to call the REopt API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
 ```
 	"distributed_generation": {
 	      "lcc_us_dollars": 100000000.0,
@@ -99,7 +99,7 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 
 
-The REopt Lite has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
 
 <b>Note:</b> Required attributes for a REopt run include latitude and longitude, parsed from the Feature or Scenario Report attributes. If no utility rate is specified in your assumptions, then a constant rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
@@ -120,19 +120,19 @@ feature_reports_hash = {} # <insert a valid Feature Report hash here with latitu
 #Create a Feature Report
 feature_report = URBANopt::Reporting::DefaultReports::FeatureReport.new(feature_reports_hash)
 
-#Specify a file name where REopt Lite results will be written in JSON format
+#Specify a file name where REopt results will be written in JSON format
 reopt_output_file = File.join(feature_report.directory_name, 'feature_report_reopt_run.json')
 
-#Specify a file name where the new timeseries CSV will be written after REopt Lite has determined cost optimal dispatch
+#Specify a file name where the new timeseries CSV will be written after REopt has determined cost optimal dispatch
 timeseries_output_file = File.join(feature_report.directory_name, 'feature_report_timeseries.csv')
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor to update the feature's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
 
 ```
@@ -162,13 +162,13 @@ scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new({:dire
   scenario_report.add_feature_report(feature_report)
 end
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), 'files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
 
 ```

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 # **URBANopt REopt Gem**
 
-The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt Lite](https://reopt.nrel.gov/tool) decision support platform.
-REopt Lite is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nrel.gov/tool) decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 See the [example project](https://github.com/urbanopt/urbanopt-example-reopt-project.git) for more infomation about usage of this gem.
 
@@ -31,7 +31,7 @@ Or install it yourself as:
 
 ## Functionality
 
-This gem is used to call the REopt Lite API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
+This gem is used to call the REopt API on a Scenario Report or Feature Report to update the object's Distributed Generation attributes (including system financial and sizing metrics) as shown in an example below:
 
 ```
 	"distributed_generation": {
@@ -83,9 +83,9 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 ```
 
-The REopt Lite has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
-<b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt Lite assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
+<b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
 
 
@@ -101,19 +101,19 @@ feature_reports_hash = {} # <insert a Feature Report hash here>
 #Create a Feature Report
 feature_report = URBANopt::Reporting::DefaultReports::FeatureReport.new(feature_reports_hash)
 
-#Specify a file name where REopt Lite results will be written in JSON format
+#Specify a file name where REopt results will be written in JSON format
 reopt_output_file = File.join(feature_report.directory_name, 'feature_report_reopt_run1.json')
 
-#Specify a file name where the new timeseries CSV will be written after REopt Lite has determined cost optimal dispatch
+#Specify a file name where the new timeseries CSV will be written after REopt has determined cost optimal dispatch
 timeseries_output_file = File.join(feature_report.directory_name, 'feature_report_timeseries1.csv')
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor to update the feature's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
 
 ```
@@ -142,13 +142,13 @@ scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new({:dire
   scenario_report.add_feature_report(feature_report)
 end
 
-#Specify non-default REopt Lite assumptions, saved in JSON format, to be used in calling the API
+#Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Lite Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
+#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
 reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
 
-#Call REopt Lite with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
+#Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
 
 ```

--- a/lib/urbanopt/reopt/feature_report_adapter.rb
+++ b/lib/urbanopt/reopt/feature_report_adapter.rb
@@ -14,7 +14,7 @@ module URBANopt # :nodoc:
   module REopt # :nodoc:
     class FeatureReportAdapter
       ##
-      # FeatureReportAdapter can convert a URBANopt::Reporting::DefaultReports::FeatureReport into a \REopt Lite posts or update a URBANopt::Reporting::DefaultReports::FeatureReport from a \REopt Lite response.
+      # FeatureReportAdapter can convert a URBANopt::Reporting::DefaultReports::FeatureReport into a \REopt posts or update a URBANopt::Reporting::DefaultReports::FeatureReport from a \REopt response.
       ##
       # [*parameters:*]
       ##
@@ -24,14 +24,14 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Convert a FeatureReport into a \REopt Lite post
+      # Convert a FeatureReport into a \REopt post
       #
       # [*parameters:*]
       #
-      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to use in converting the optional +reopt_assumptions_hash+ to a \REopt Lite post. If a +reopt_assumptions_hash+ is not provided, a default post will be updated from this FeatureReport and submitted to the \REopt Lite API.
-      # *  +reopt_assumptions_hash+ - _Hash_ - Optional. A hash formatted for submittal to the \REopt Lite API containing default values. Values will be overwritten from the FeatureReport where available (i.e. latitude, roof_squarefeet). Missing optional parameters will be filled in with default values by the API.
+      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to use in converting the optional +reopt_assumptions_hash+ to a \REopt post. If a +reopt_assumptions_hash+ is not provided, a default post will be updated from this FeatureReport and submitted to the \REopt API.
+      # *  +reopt_assumptions_hash+ - _Hash_ - Optional. A hash formatted for submittal to the \REopt API containing default values. Values will be overwritten from the FeatureReport where available (i.e. latitude, roof_squarefeet). Missing optional parameters will be filled in with default values by the API.
       #
-      # [*return:*] _Hash_ - Returns hash formatted for submittal to the \REopt Lite API
+      # [*return:*] _Hash_ - Returns hash formatted for submittal to the \REopt API
       ##
       def reopt_json_from_feature_report(feature_report, reopt_assumptions_hash = nil, groundmount_photovoltaic = nil)
         name = feature_report.name.delete ' '
@@ -40,7 +40,7 @@ module URBANopt # :nodoc:
         if !reopt_assumptions_hash.nil?
           reopt_inputs = reopt_assumptions_hash
         else
-          @@logger.info('Using default REopt Lite assumptions')
+          @@logger.info('Using default REopt assumptions')
         end
 
         # Check FeatureReport has required data
@@ -104,7 +104,7 @@ module URBANopt # :nodoc:
           end
           # Clip to one non-leap year's worth of data
           energy_timeseries_kw = energy_timeseries_kw.map { |e| e || 0 }[0, (feature_report.timesteps_per_hour * 8760)]
-          # Convert from the OpenDSS resolution to the REopt Lite resolution, if necessary
+          # Convert from the OpenDSS resolution to the REopt resolution, if necessary
         rescue StandardError
           @@logger.error("Could not parse the annual electric load from the timeseries csv - #{feature_report.timeseries_csv.path}")
           raise "Could not parse the annual electric load from the timeseries csv - #{feature_report.timeseries_csv.path}"
@@ -136,18 +136,18 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Update a FeatureReport from a \REopt Lite response
+      # Update a FeatureReport from a \REopt response
       #
       # [*parameters:*]
       #
-      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to update from a \REopt Lite reponse hash.
-      # * +reopt_output+ - _Hash_ - A reponse hash from the \REopt Lite API to use in overwriting FeatureReport technology sizes, costs and dispatch strategies.
-      # * +timeseries_csv_path+ - _String_ - Optional. The path to a file at which a new timeseries CSV will be written. If not provided a file is created based on the run_uuid of the \REopt Lite optimization task.
+      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to update from a \REopt reponse hash.
+      # * +reopt_output+ - _Hash_ - A reponse hash from the \REopt API to use in overwriting FeatureReport technology sizes, costs and dispatch strategies.
+      # * +timeseries_csv_path+ - _String_ - Optional. The path to a file at which a new timeseries CSV will be written. If not provided a file is created based on the run_uuid of the \REopt optimization task.
       #
       # [*return:*] _URBANopt::Reporting::DefaultReports::FeatureReport_ - Returns an updated FeatureReport.
       ##
       def update_feature_report(feature_report, reopt_output, timeseries_csv_path = nil, resilience_stats = nil)
-        # Check if the \REopt Lite response is valid
+        # Check if the \REopt response is valid
         if reopt_output['outputs']['Scenario']['status'] != 'optimal'
           @@logger.info("Warning cannot Feature Report #{feature_report.name} #{feature_report.id}  - REopt optimization was non-optimal")
           return feature_report

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -16,15 +16,15 @@ module URBANopt # :nodoc:
   module REopt  # :nodoc:
     class REoptLiteAPI
       ##
-      # \REoptLiteAPI manages submitting optimization tasks to the \REopt Lite API  and recieving results.
-      # Results can either be sourced from the production \REopt Lite API with an API key from developer.nrel.gov, or from
+      # \REoptLiteAPI manages submitting optimization tasks to the \REopt API  and recieving results.
+      # Results can either be sourced from the production \REopt API with an API key from developer.nrel.gov, or from
       # a version running at localhost.
       ##
       #
       # [*parameters:*]
       #
-      # * +use_localhost+ - _Bool_ - If this is true, requests will be sent to a version of the \REopt Lite API running on localhost. Default is false, such that the production version of \REopt Lite is accessed.
-      # * +nrel_developer_key+ - _String_ - API key used to access the \REopt Lite APi. Required only if localhost is false. Obtain from https://developer.nrel.gov/signup/
+      # * +use_localhost+ - _Bool_ - If this is true, requests will be sent to a version of the \REopt API running on localhost. Default is false, such that the production version of \REopt is accessed.
+      # * +nrel_developer_key+ - _String_ - API key used to access the \REopt APi. Required only if localhost is false. Obtain from https://developer.nrel.gov/signup/
       ##
       def initialize(nrel_developer_key = nil, use_localhost = false)
         @use_localhost = use_localhost
@@ -53,9 +53,9 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +run_uuid+ - _String_ - Unique run_uuid obtained from the \REopt Lite job submittal URL for a specific optimization task.
+      # * +run_uuid+ - _String_ - Unique run_uuid obtained from the \REopt job submittal URL for a specific optimization task.
       #
-      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt Lite results endpoint for a specifc optimization task.
+      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt results endpoint for a specifc optimization task.
       ##
       def uri_results(run_uuid) # :nodoc:
         if @use_localhost
@@ -71,9 +71,9 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +run_uuid+ - _String_ - Resilience statistics for a unique run_uuid obtained from the \REopt Lite job submittal URL for a specific optimization task.
+      # * +run_uuid+ - _String_ - Resilience statistics for a unique run_uuid obtained from the \REopt job submittal URL for a specific optimization task.
       #
-      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt Lite resilience statistics endpoint for a specifc optimization task.
+      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt resilience statistics endpoint for a specifc optimization task.
       ##
       def uri_resilience(run_uuid) # :nodoc:
         if @use_localhost
@@ -91,7 +91,7 @@ module URBANopt # :nodoc:
             result = http.request(req)
             # Result codes sourced from https://developer.nrel.gov/docs/errors/
             if result.code == '429'
-              @@logger.fatal('Exceeded the REopt-Lite API limit of 300 requests per hour')
+              @@logger.fatal('Exceeded the REopt API limit of 300 requests per hour')
               puts 'Using the URBANopt CLI to submit a Scenario optimization counts as one request per scenario'
               puts 'Using the URBANopt CLI to submit a Feature optimization counts as one request per feature'
               abort('Please wait and try again once the time period has elapsed.  The URBANopt CLI flag --reopt-keep-existing can be used to resume the optimization')
@@ -101,7 +101,7 @@ module URBANopt # :nodoc:
               tries += 1
               next
             elsif (result.code != '201') && (result.code != '200') # Anything in the 200s is success
-              @@logger.warn("REopt-Lite has returned a '#{result.code}' status code. Visit https://developer.nrel.gov/docs/errors/ for more status code information")
+              @@logger.warn("REopt has returned a '#{result.code}' status code. Visit https://developer.nrel.gov/docs/errors/ for more status code information")
               # display error messages
               json_res = JSON.parse(result.body, allow_nan: true)
               json_res['messages'].delete('warnings') if json_res['messages']['warnings']
@@ -112,7 +112,7 @@ module URBANopt # :nodoc:
             end
             tries = max_tries
           rescue StandardError => e
-            @@logger.debug("error from REopt lite API: #{e}")
+            @@logger.debug("error from REopt API: #{e}")
             if tries + 1 < max_tries
               @@logger.debug('trying again...')
             else
@@ -126,12 +126,12 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Checks if a optimization task can be submitted to the \REopt Lite API
+      # Checks if a optimization task can be submitted to the \REopt API
       ##
       #
       # [*parameters:*]
       #
-      # * +data+ - _Hash_ - Default \REopt Lite formatted post containing at least all the required parameters.
+      # * +data+ - _Hash_ - Default \REopt formatted post containing at least all the required parameters.
       #
       # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
       ##
@@ -156,15 +156,15 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Completes a \REopt Lite optimization. From a formatted hash, an optimization task is submitted to the API.
+      # Completes a \REopt optimization. From a formatted hash, an optimization task is submitted to the API.
       # Results are polled at 5 second interval until they are ready or an error is returned from the API. Results
       # are written to disk.
       ##
       #
       # [*parameters:*]
       #
-      # * +reopt_input+ - _Hash_ - \REopt Lite formatted post containing at least required parameters.
-      # * +filename+ - _String_ - Path to file that will be created containing the full \REopt Lite response.
+      # * +reopt_input+ - _Hash_ - \REopt formatted post containing at least required parameters.
+      # * +filename+ - _String_ - Path to file that will be created containing the full \REopt response.
       #
       # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
       ##
@@ -211,7 +211,7 @@ module URBANopt # :nodoc:
         # If database still hasn't updated, wait a little longer and try again
         while (elapsed_time < max_elapsed_time) && (response && response.code == '404')
           response = make_request(http, get_request)
-          @@logger.warn('GET request was too fast for REOpt-Lite API. Retrying...')
+          @@logger.warn('GET request was too fast for REOpt-API. Retrying...')
           elapsed_time += 5
           sleep 5
         end
@@ -236,22 +236,22 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Completes a \REopt Lite optimization. From a formatted hash, an optimization task is submitted to the API.
+      # Completes a \REopt optimization. From a formatted hash, an optimization task is submitted to the API.
       # Results are polled at 5 second interval until they are ready or an error is returned from the API. Results
       # are written to disk.
       ##
       #
       # [*parameters:*]
       #
-      # * +reopt_input+ - _Hash_ - \REopt Lite formatted post containing at least required parameters.
-      # * +filename+ - _String_ - Path to file that will be created containing the full \REopt Lite response.
+      # * +reopt_input+ - _Hash_ - \REopt formatted post containing at least required parameters.
+      # * +filename+ - _String_ - Path to file that will be created containing the full \REopt response.
       #
       # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
       ##
       def reopt_request(reopt_input, filename)
         description = reopt_input[:Scenario][:description]
 
-        @@logger.info("Submitting #{description} to REopt Lite API")
+        @@logger.info("Submitting #{description} to REopt API")
 
         # Format the request
         header = { 'Content-Type' => 'application/json' }

--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -12,16 +12,16 @@ module URBANopt # :nodoc:
   module REopt # :nodoc:
     class REoptPostProcessor
       ##
-      # \REoptPostProcessor updates a ScenarioReport or FeatureReport based on \REopt Lite optimization response.
+      # \REoptPostProcessor updates a ScenarioReport or FeatureReport based on \REopt optimization response.
       ##
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _ScenarioReport_ - Optional. A scenario report that has been returned from the URBANopt::Reporting::ScenarioDefaultPostProcessor - used in creating default output file names in \REopt Lite optimizations.
-      # * +scenario_reopt_assumptions_file+ - _String_ - Optional. JSON file formatted for a \REopt Lite analysis containing custom input parameters for optimizations at the Scenario Report level
-      # * +reopt_feature_assumptions+ - _Array_ - Optional. A list of JSON file formatted for a \REopt Lite analysis containing custom input parameters for optimizations at the Feature Report level. The order and number of files must match the Feature Reports in the scenario_report input.
-      # * +use_localhost+ - _Bool_ - If this is true, requests will be sent to a version of the \REopt Lite API running on localhost. Default is false, such that the production version of \REopt Lite is accessed.
-      # * +nrel_developer_key+ - _String_ - API used to access the \REopt Lite APi. Required only if +localhost+ is false. Obtain from https://developer.nrel.gov/signup/
+      # * +scenario_report+ - _ScenarioReport_ - Optional. A scenario report that has been returned from the URBANopt::Reporting::ScenarioDefaultPostProcessor - used in creating default output file names in \REopt optimizations.
+      # * +scenario_reopt_assumptions_file+ - _String_ - Optional. JSON file formatted for a \REopt analysis containing custom input parameters for optimizations at the Scenario Report level
+      # * +reopt_feature_assumptions+ - _Array_ - Optional. A list of JSON file formatted for a \REopt analysis containing custom input parameters for optimizations at the Feature Report level. The order and number of files must match the Feature Reports in the scenario_report input.
+      # * +use_localhost+ - _Bool_ - If this is true, requests will be sent to a version of the \REopt API running on localhost. Default is false, such that the production version of \REopt is accessed.
+      # * +nrel_developer_key+ - _String_ - API used to access the \REopt APi. Required only if +localhost+ is false. Obtain from https://developer.nrel.gov/signup/
       ##
       def initialize(scenario_report, scenario_reopt_assumptions_file = nil, reopt_feature_assumptions = [], nrel_developer_key = nil, localhost = false)
         # initialize @@logger
@@ -80,14 +80,14 @@ module URBANopt # :nodoc:
       attr_accessor :scenario_reopt_default_assumptions_hash, :scenario_reopt_default_output_file, :scenario_timeseries_default_output_file, :feature_reports_reopt_default_assumption_hashes, :feature_reports_reopt_default_output_files, :feature_reports_timeseries_default_output_files
 
       ##
-      # Updates a FeatureReport based on an optional set of \REopt Lite optimization assumptions.
+      # Updates a FeatureReport based on an optional set of \REopt optimization assumptions.
       ##
       #
       # [*parameters:*]
       #
-      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ -  FeatureReport which will be used in creating and then updated by a \REopt Lite opimization response.
-      # * +reopt_assumptions_hash+ - _Hash_ - Optional. A \REopt Lite formatted hash containing default parameters (i.e. utility rate, escalation rate) which will be updated by the FeatureReport (i.e. location, roof availability)
-      # * +reopt_output_file+ - _String_ - Optional. Path to a file at which REpopt Lite responses will be saved.
+      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ -  FeatureReport which will be used in creating and then updated by a \REopt opimization response.
+      # * +reopt_assumptions_hash+ - _Hash_ - Optional. A \REopt formatted hash containing default parameters (i.e. utility rate, escalation rate) which will be updated by the FeatureReport (i.e. location, roof availability)
+      # * +reopt_output_file+ - _String_ - Optional. Path to a file at which REpopt responses will be saved.
       # * +timeseries_csv_path+ - _String_ - Optional. Path to a file at which the new timeseries CSV for the FeatureReport will be saved.
       #
       # [*return:*] _URBANopt::Reporting::DefaultReports::FeatureReport_ - Returns an updated FeatureReport
@@ -120,14 +120,14 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Updates a ScenarioReport based on an optional set of \REopt Lite optimization assumptions.
+      # Updates a ScenarioReport based on an optional set of \REopt optimization assumptions.
       ##
       #
       # [*parameters:*]
       #
-      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ -  ScenarioReport which will be used in creating and then updated by a \REopt Lite opimization response.
-      # * +reopt_assumptions_hash+ - _Hash_ - Optional. A \REopt Lite formatted hash containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability)
-      # * +reopt_output_file+ - _String_ - Optional. Path to a file at which REpopt Lite responses will be saved.
+      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ -  ScenarioReport which will be used in creating and then updated by a \REopt opimization response.
+      # * +reopt_assumptions_hash+ - _Hash_ - Optional. A \REopt formatted hash containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability)
+      # * +reopt_output_file+ - _String_ - Optional. Path to a file at which REpopt responses will be saved.
       # * +timeseries_csv_path+ - _String_ - Optional. Path to a file at which the new timeseries CSV for the ScenarioReport will be saved.
       #
       # [*return:*] _URBANopt::Scenario::DefaultReports::ScenarioReport_ Returns an updated ScenarioReport
@@ -176,14 +176,14 @@ module URBANopt # :nodoc:
         return result
       end
 
-      # Updates a set of FeatureReports based on an optional set of \REopt Lite optimization assumptions.
+      # Updates a set of FeatureReports based on an optional set of \REopt optimization assumptions.
       ##
       #
       # [*parameters:*]
       #
-      # * +feature_reports+ - _Array_ -  An array of _URBANopt::Reporting::DefaultReports::FeatureReport_ objetcs which will each be used to create (and are subsquently updated by) a \REopt Lite opimization response.
-      # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt Lite formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the feature_reports array.
-      # * +reopt_output_files+ - _Array_ - Optional. A array of paths to files at which REpopt Lite responses will be saved. The number and order of the paths should match the feature_reports array.
+      # * +feature_reports+ - _Array_ -  An array of _URBANopt::Reporting::DefaultReports::FeatureReport_ objetcs which will each be used to create (and are subsquently updated by) a \REopt opimization response.
+      # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the feature_reports array.
+      # * +reopt_output_files+ - _Array_ - Optional. A array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the feature_reports array.
       # * +timeseries_csv_path+ - _Array_ - Optional. A array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the feature_reports array.
       #
       # [*return:*] _Array_ Returns an array of updated _URBANopt::Scenario::DefaultReports::FeatureReport_ objects
@@ -257,7 +257,7 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +output_file+ - _Array_ - Optional. An array of paths to files at which REpopt Lite responses will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
+      # * +output_file+ - _Array_ - Optional. An array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
       # [*return:*] _Boolean_ - Returns true if file or nonempty directory exist
       def output_exists(output_file)
         res = false
@@ -270,14 +270,14 @@ module URBANopt # :nodoc:
         return res
       end
 
-      # Updates a ScenarioReport based on an optional set of \REopt Lite optimization assumptions.
+      # Updates a ScenarioReport based on an optional set of \REopt optimization assumptions.
       ##
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _Array_ -  A _URBANopt::Reporting::DefaultReports::ScenarioReport_ which will each be used to create (and is subsquently updated by) \REopt Lite opimization responses for each of its FeatureReports.
-      # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt Lite formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the array in ScenarioReport.feature_reports.
-      # * +reopt_output_files+ - _Array_ - Optional. An array of paths to files at which REpopt Lite responses will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
+      # * +scenario_report+ - _Array_ -  A _URBANopt::Reporting::DefaultReports::ScenarioReport_ which will each be used to create (and is subsquently updated by) \REopt opimization responses for each of its FeatureReports.
+      # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the array in ScenarioReport.feature_reports.
+      # * +reopt_output_files+ - _Array_ - Optional. An array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
       # * +feature_report_timeseries_csv_paths+ - _Array_ - Optional. An array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
       #
       # [*return:*] _URBANopt::Scenario::DefaultReports::ScenarioReport_ - Returns an updated ScenarioReport

--- a/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
+++ b/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"description": "Data Dictionary for REopt Lite Inputs",
+	"description": "Data Dictionary for REopt Inputs",
 	"type": "object",
 	"properties": {
 		"$ref": "#/definitions/Scenario"

--- a/lib/urbanopt/reopt/reopt_schema/reopt_output_schema.json
+++ b/lib/urbanopt/reopt/reopt_schema/reopt_output_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Data Dictionary for REopt Lite Outputs",
+  "description": "Data Dictionary for REopt Outputs",
   "type": "object",
   "properties": {
     "$ref": "#/definitions/Response"

--- a/lib/urbanopt/reopt/scenario/reopt_scenario_csv.rb
+++ b/lib/urbanopt/reopt/scenario/reopt_scenario_csv.rb
@@ -16,9 +16,9 @@ module URBANopt
     class REoptScenarioCSV < ScenarioCSV
       ##
       # REoptScenarioCSV is an extension of ScenarioCSV which assigns a Simulation Mapper to each Feature in a FeatureFile using a simple CSV format.
-      # The a \REopt Lite enabled CSV file has four columns 1) feature_id, 2) feature_name, 3) mapper_class_name and 4) optional reopt assumptions file name.  There is one row for each Feature.
-      # A REoptScenarioCSV can be instantiated with set of assumptions to use in \REopt Lite for an optimization at the aggregated ScenarioReport level.
-      # A REoptScenarioCSV is also instantiated with a +reopt_files_dir+ file directory containing all \REopt Lite assumptions files (required only if the ScenarioReport or its FeatureReports will have specified assumptions).
+      # The a \REopt enabled CSV file has four columns 1) feature_id, 2) feature_name, 3) mapper_class_name and 4) optional reopt assumptions file name.  There is one row for each Feature.
+      # A REoptScenarioCSV can be instantiated with set of assumptions to use in \REopt for an optimization at the aggregated ScenarioReport level.
+      # A REoptScenarioCSV is also instantiated with a +reopt_files_dir+ file directory containing all \REopt assumptions files (required only if the ScenarioReport or its FeatureReports will have specified assumptions).
       #
       # [*parameters:*]
       #
@@ -29,8 +29,8 @@ module URBANopt
       # * +mapper_files_dir+ - _String_ - Directory containing all mapper class files containing MapperBase definitions.
       # * +csv_file+ - _String_ - Path to CSV file assigning a MapperBase class to each feature in feature_file.
       # * +num_header_rows+ - _String_ - Number of header rows to skip in CSV file.
-      # * +reopt_files_dir+ - _String_ - Path to folder containing default \REopt Lite assumptions JSON's.
-      # * +scenario_reopt_assumptions_file_name+ - _String_ - Name of .json file in the +reopt_files_dir+ location to use in assessing the aggregated ScenarioReport in \REopt Lite.
+      # * +reopt_files_dir+ - _String_ - Path to folder containing default \REopt assumptions JSON's.
+      # * +scenario_reopt_assumptions_file_name+ - _String_ - Name of .json file in the +reopt_files_dir+ location to use in assessing the aggregated ScenarioReport in \REopt.
       ##
       def initialize(name, root_dir, run_dir, feature_file, mapper_files_dir, csv_file, num_header_rows, reopt_files_dir = nil, scenario_reopt_assumptions_file_name = nil)
         super(name, root_dir, run_dir, feature_file, mapper_files_dir, csv_file, num_header_rows)
@@ -66,12 +66,12 @@ module URBANopt
           feature_id = row[0].chomp
           feature_name = row[1].chomp
           mapper_class = row[2].chomp
-          # Assume fourth columns, if exists, contains the name of the JSON file in the reopt_files_dir to use when running \REopt Lite for the feature report
+          # Assume fourth columns, if exists, contains the name of the JSON file in the reopt_files_dir to use when running \REopt for the feature report
 
           if row.length > 3 && !@reopt_files_dir.nil?
             @reopt_feature_assumptions[idx - 1] = File.join(@reopt_files_dir, row[3].chomp)
           end
-          
+
           # gets +features+ from the feature_file.
           features = []
           feature = feature_file.get_feature_by_id(feature_id)

--- a/lib/urbanopt/reopt/scenario_report_adapter.rb
+++ b/lib/urbanopt/reopt/scenario_report_adapter.rb
@@ -14,7 +14,7 @@ module URBANopt # :nodoc:
   module REopt # :nodoc:
     class ScenarioReportAdapter
       ##
-      # ScenarioReportAdapter can convert a ScenarioReport into a \REopt Lite posts or updates a ScenarioReport and its FeatureReports from \REopt Lite response(s)
+      # ScenarioReportAdapter can convert a ScenarioReport into a \REopt posts or updates a ScenarioReport and its FeatureReports from \REopt response(s)
       ##
       # [*parameters:*]
       def initialize
@@ -23,26 +23,26 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Convert a ScenarioReport into a \REopt Lite post
+      # Convert a ScenarioReport into a \REopt post
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ - ScenarioReport to use in converting the +reopt_assumptions_hash+, if provided, to a \REopt Lite post. Otherwise, if the +reopt_assumptions_hash+ is nil a default post will be updated from this ScenarioReport and submitted to the \REopt Lite API.
-      # * +reopt_assumptions_hash+ - _Hash_ - Optional. A hash formatted for submittal to the \REopt Lite API containing default values. Values will be overwritten from the ScenarioReport where available (i.e. latitude, roof_squarefeet). Missing optional parameters will be filled in with default values by the API.
+      # * +scenario_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ - ScenarioReport to use in converting the +reopt_assumptions_hash+, if provided, to a \REopt post. Otherwise, if the +reopt_assumptions_hash+ is nil a default post will be updated from this ScenarioReport and submitted to the \REopt API.
+      # * +reopt_assumptions_hash+ - _Hash_ - Optional. A hash formatted for submittal to the \REopt API containing default values. Values will be overwritten from the ScenarioReport where available (i.e. latitude, roof_squarefeet). Missing optional parameters will be filled in with default values by the API.
       #
-      # [*return:*] _Hash_ - Returns hash formatted for submittal to the \REopt Lite API
+      # [*return:*] _Hash_ - Returns hash formatted for submittal to the \REopt API
       ##
       def reopt_json_from_scenario_report(scenario_report, reopt_assumptions_json = nil, community_photovoltaic = nil)
         name = scenario_report.name.delete ' '
         scenario_id = scenario_report.id.delete ' '
         description = "scenario_report_#{name}_#{scenario_id}"
 
-        # Create base REpopt Lite post
+        # Create base REpopt post
         reopt_inputs = { Scenario: { Site: { ElectricTariff: { blended_monthly_demand_charges_us_dollars_per_kw: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], blended_monthly_rates_us_dollars_per_kwh: [0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13] }, LoadProfile: {}, Wind: { max_kw: 0 } } } }
         if !reopt_assumptions_json.nil?
           reopt_inputs = reopt_assumptions_json
         else
-          @@logger.info('Using default REopt Lite assumptions')
+          @@logger.info('Using default REopt assumptions')
         end
 
         # Update required info
@@ -144,14 +144,14 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Converts a FeatureReport list from a ScenarioReport into an array of \REopt Lite posts
+      # Converts a FeatureReport list from a ScenarioReport into an array of \REopt posts
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ - ScenarioReport to use in converting FeatureReports and respecitive +reopt_assumptions_hashes+, if provided, to a \REopt Lite post. If no +reopt_assumptions_hashes+ are provided default posts will be updated from these FeatureReports and submitted to the \REopt Lite API.
-      # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of hashes formatted for submittal to the \REopt Lite API containing default values. Values will be overwritten from the ScenarioReport where available (i.e. latitude, roof_squarefeet). Missing optional parameters will be filled in with default values by the API. The order should match the list in ScenarioReport.feature_reports.
+      # * +scenario_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ - ScenarioReport to use in converting FeatureReports and respecitive +reopt_assumptions_hashes+, if provided, to a \REopt post. If no +reopt_assumptions_hashes+ are provided default posts will be updated from these FeatureReports and submitted to the \REopt API.
+      # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of hashes formatted for submittal to the \REopt API containing default values. Values will be overwritten from the ScenarioReport where available (i.e. latitude, roof_squarefeet). Missing optional parameters will be filled in with default values by the API. The order should match the list in ScenarioReport.feature_reports.
       #
-      # [*return:*] _Array_ - Returns an array of hashes formatted for submittal to the \REopt Lite API in the order of the FeatureReports lited in ScenarioReport.feature_reports.
+      # [*return:*] _Array_ - Returns an array of hashes formatted for submittal to the \REopt API in the order of the FeatureReports lited in ScenarioReport.feature_reports.
       ##
       def reopt_jsons_from_scenario_feature_reports(scenario_report, reopt_assumptions_hashes = [])
         results = []
@@ -189,13 +189,13 @@ module URBANopt # :nodoc:
       end
 
       ##
-      # Updates a ScenarioReport from a \REopt Lite response
+      # Updates a ScenarioReport from a \REopt response
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ - ScenarioReport to update from a \REopt Lite response.
-      # * +reopt_output+ - _Hash_ - A hash response from the \REopt Lite API.
-      # * +timeseries_csv_path+ - _String_ - Optional. The path to a file at which new timeseries data will be written. If not provided a file is created based on the run_uuid of the \REopt Lite optimization task.
+      # * +scenario_report+ - _URBANopt::Reporting::DefaultReports::ScenarioReport_ - ScenarioReport to update from a \REopt response.
+      # * +reopt_output+ - _Hash_ - A hash response from the \REopt API.
+      # * +timeseries_csv_path+ - _String_ - Optional. The path to a file at which new timeseries data will be written. If not provided a file is created based on the run_uuid of the \REopt optimization task.
       #
       # [*return:*] _URBANopt::Reporting::DefaultReports::ScenarioReport_ - Returns an updated ScenarioReport
       ##

--- a/spec/tests/urbanopt_reopt_spec.rb
+++ b/spec/tests/urbanopt_reopt_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe URBANopt::REopt do
     expect(URBANopt::REopt::VERSION).not_to be nil
   end
 
-  it 'can connect to reopt lite' do
+  it 'can connect to reopt' do
     api = URBANopt::REopt::REoptLiteAPI.new(DEVELOPER_NREL_KEY, false)
     dummy_data = { Scenario: { Site: { latitude: 40, longitude: -110, Wind: { max_kw: 0 }, ElectricTariff: { urdb_label: '594976725457a37b1175d089' }, LoadProfile: { doe_reference_name: 'Hospital', annual_kwh: 1000000 } } } }
     ok = api.check_connection(dummy_data)
@@ -40,7 +40,7 @@ RSpec.describe URBANopt::REopt do
 
     # Send the request, test response
     expect { api.make_request(http, post_request) }
-      .to output(a_string_including('REopt-Lite has returned'))
+      .to output(a_string_including('REopt has returned'))
       .to_stdout_from_any_process
   end
 

--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.email         = ['']
   spec.licenses      = 'Nonstandard'
 
-  spec.summary       = 'Accessing the REopt Lite API within OpenStudio workflows.'
-  spec.description   = 'Classes and measures for utilizing the REopt Lite API within OpenStudio workflows.'
+  spec.summary       = 'Accessing the REopt API within OpenStudio workflows.'
+  spec.description   = 'Classes and measures for utilizing the REopt API within OpenStudio workflows.'
   spec.homepage      = 'https://github.com/urbanopt/urbanopt-reopt-gem'
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
### Resolves #130

### Pull Request Description
Removes "lite" descriptor from REopt name

### Checklist

- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
