### PR TITLE
Use different error messages in different places

### DIFF
--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -266,7 +266,7 @@ module URBANopt # :nodoc:
         response = make_request(http, post_request)
         if !response.is_a?(Net::HTTPSuccess)
           @@logger.error('make_request Failed')
-          raise 'Check_connection Failed'
+          raise 'REopt connection Failed'
         end
 
         # Get UUID


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

Change the error message so it's differentiated from the message in the `check_connection` method

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
