### PR TITLE
expose error messages for certificate verify failed

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -2,13 +2,11 @@ name: REopt-gem CI
 
 on:
   workflow_dispatch:
-  # push:
+  push:
   schedule:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5:23 am UTC (11:23pm MDT the day before) every weekday night in MDT
     - cron: '23 5 * * 2-6'
-  pull_request:
-    types: [review_requested]
 
 env:
   # This env var should enforce develop branch of all dependencies

--- a/lib/urbanopt/reopt/feature_report_adapter.rb
+++ b/lib/urbanopt/reopt/feature_report_adapter.rb
@@ -151,8 +151,8 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to update from a \REopt reponse hash.
-      # * +reopt_output+ - _Hash_ - A reponse hash from the \REopt API to use in overwriting FeatureReport technology sizes, costs and dispatch strategies.
+      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to update from a \REopt response hash.
+      # * +reopt_output+ - _Hash_ - A response hash from the \REopt API to use in overwriting FeatureReport technology sizes, costs and dispatch strategies.
       # * +timeseries_csv_path+ - _String_ - Optional. The path to a file at which a new timeseries CSV will be written. If not provided a file is created based on the run_uuid of the \REopt optimization task.
       #
       # [*return:*] _URBANopt::Reporting::DefaultReports::FeatureReport_ - Returns an updated FeatureReport.

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -112,7 +112,8 @@ module URBANopt # :nodoc:
             end
             tries = max_tries
           rescue StandardError => e
-            @@logger.debug("error from REopt API: #{e}")
+            @@logger.error("error from REopt API: #{e}")
+            puts "Error from REopt API: #{e}"
             if tries + 1 < max_tries
               @@logger.debug('trying again...')
             else

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -16,7 +16,7 @@ module URBANopt # :nodoc:
   module REopt  # :nodoc:
     class REoptLiteAPI
       ##
-      # \REoptLiteAPI manages submitting optimization tasks to the \REopt API  and recieving results.
+      # \REoptLiteAPI manages submitting optimization tasks to the \REopt API  and receiving results.
       # Results can either be sourced from the production \REopt API with an API key from developer.nrel.gov, or from
       # a version running at localhost.
       ##
@@ -55,7 +55,7 @@ module URBANopt # :nodoc:
       #
       # * +run_uuid+ - _String_ - Unique run_uuid obtained from the \REopt job submittal URL for a specific optimization task.
       #
-      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt results endpoint for a specifc optimization task.
+      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt results endpoint for a specific optimization task.
       ##
       def uri_results(run_uuid) # :nodoc:
         if @use_localhost
@@ -73,7 +73,7 @@ module URBANopt # :nodoc:
       #
       # * +run_uuid+ - _String_ - Resilience statistics for a unique run_uuid obtained from the \REopt job submittal URL for a specific optimization task.
       #
-      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt resilience statistics endpoint for a specifc optimization task.
+      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt resilience statistics endpoint for a specific optimization task.
       ##
       def uri_resilience(run_uuid) # :nodoc:
         if @use_localhost
@@ -134,7 +134,7 @@ module URBANopt # :nodoc:
       #
       # * +data+ - _Hash_ - Default \REopt formatted post containing at least all the required parameters.
       #
-      # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
+      # [*return:*] _Bool_ - Returns true if the post succeeds. Otherwise returns false.
       ##
       def check_connection(data)
         header = { 'Content-Type' => 'application/json' }
@@ -167,7 +167,7 @@ module URBANopt # :nodoc:
       # * +reopt_input+ - _Hash_ - \REopt formatted post containing at least required parameters.
       # * +filename+ - _String_ - Path to file that will be created containing the full \REopt response.
       #
-      # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
+      # [*return:*] _Bool_ - Returns true if the post succeeds. Otherwise returns false.
       ##
       def resilience_request(run_uuid, filename)
         if File.directory? filename
@@ -247,7 +247,7 @@ module URBANopt # :nodoc:
       # * +reopt_input+ - _Hash_ - \REopt formatted post containing at least required parameters.
       # * +filename+ - _String_ - Path to file that will be created containing the full \REopt response.
       #
-      # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
+      # [*return:*] _Bool_ - Returns true if the post succeeds. Otherwise returns false.
       ##
       def reopt_request(reopt_input, filename)
         description = reopt_input[:description]

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -113,7 +113,6 @@ module URBANopt # :nodoc:
             tries = max_tries
           rescue StandardError => e
             @@logger.error("error from REopt API: #{e}")
-            puts "Error from REopt API: #{e}"
             if tries + 1 < max_tries
               @@logger.debug('trying again...')
             else

--- a/lib/urbanopt/reopt/reopt_logger.rb
+++ b/lib/urbanopt/reopt/reopt_logger.rb
@@ -12,7 +12,7 @@ module URBANopt
     # Set Logger::DEBUG for development
     @@reopt_logger.level = Logger::WARN
     ##
-    # Definining class variable "@@logger" to log errors, info and warning messages.
+    # Defining class variable "@@logger" to log errors, info and warning messages.
     def self.reopt_logger
       @@reopt_logger
     end

--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -182,7 +182,7 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +feature_reports+ - _Array_ -  An array of _URBANopt::Reporting::DefaultReports::FeatureReport_ objetcs which will each be used to create (and are subsquently updated by) a \REopt opimization response.
+      # * +feature_reports+ - _Array_ -  An array of _URBANopt::Reporting::DefaultReports::FeatureReport_ objects which will each be used to create (and are subsequently updated by) a \REopt opimization response.
       # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the feature_reports array.
       # * +reopt_output_files+ - _Array_ - Optional. A array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the feature_reports array.
       # * +timeseries_csv_path+ - _Array_ - Optional. A array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the feature_reports array.
@@ -276,7 +276,7 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _Array_ -  A _URBANopt::Reporting::DefaultReports::ScenarioReport_ which will each be used to create (and is subsquently updated by) \REopt opimization responses for each of its FeatureReports.
+      # * +scenario_report+ - _Array_ -  A _URBANopt::Reporting::DefaultReports::ScenarioReport_ which will each be used to create (and is subsequently updated by) \REopt opimization responses for each of its FeatureReports.
       # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the array in ScenarioReport.feature_reports.
       # * +reopt_output_files+ - _Array_ - Optional. An array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
       # * +feature_report_timeseries_csv_paths+ - _Array_ - Optional. An array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.

--- a/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
+++ b/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
@@ -101,7 +101,7 @@
 					"min": 0,
 					"max": 1000000.0,
 					"type": "number",
-					"description": "Value placed on unmet site load during grid outages. Units are US dollars per unmet kilowatt-hour. The value of lost load (VoLL) is used to determine the avoided outage costs by multiplying VoLL [$/kWh] with the average number of hours that the critical load can be met by the energy system (determined by simulating outages occuring at every hour of the year), and multiplying by the mean critical load."
+					"description": "Value placed on unmet site load during grid outages. Units are US dollars per unmet kilowatt-hour. The value of lost load (VoLL) is used to determine the avoided outage costs by multiplying VoLL [$/kWh] with the average number of hours that the critical load can be met by the energy system (determined by simulating outages occurring at every hour of the year), and multiplying by the mean critical load."
 				},
 				"analysis_years": {
 					"default": 20,
@@ -711,7 +711,7 @@
 					"min": 0,
 					"max": 1,
 					"type": "number",
-					"description": "Fraction of upfront project costs to depreciate under MACRS in year one in addtion to scheduled depreciation"
+					"description": "Fraction of upfront project costs to depreciate under MACRS in year one in addition to scheduled depreciation"
 				},
 				"inverter_replacement_year": {
 					"default": 10,

--- a/lib/urbanopt/reopt/utilities.rb
+++ b/lib/urbanopt/reopt/utilities.rb
@@ -36,7 +36,7 @@ def convert_powerflow_resolution(timeseries_kw, original_res, destination_res)
     current_origin_idx = 0 # current integer index of the origin timeseries
     (0..(8760 * destination_res - 1)).each do |ts|
       next_stopping_ts = current_origin_ts + stepping_interval # stop at the next destination interval
-      total_power = [] # create to store wieghted origin timestep values to average
+      total_power = [] # create to store weighted origin timestep values to average
       while current_origin_ts != next_stopping_ts
         next_origin_ts_int = Integer(current_origin_ts) + 1
         # Calc next stopping point that will being you to the next origin or destination time step
@@ -61,7 +61,7 @@ def convert_powerflow_resolution(timeseries_kw, original_res, destination_res)
     # Timesteps will be expanded, i.e. 8760 -> 35040
 
     # This algorithm works by stepping along the destination timeseries. Steps are made to the next
-    # destination or origin breakpoint, and at each step the propotional amount of the origin stepped
+    # destination or origin breakpoint, and at each step the proportional amount of the origin stepped
     # is added to the destination. For example, in in EX 1 below 4 steps are made each with adding the full amount of
     # the origin (1, 1, 2 and 2) since each in the destination overlaps perfectly with 2 origin
     # timesteps. In EX 2, the origin overlaps with the first 2 destination timesteps but the third


### PR DESCRIPTION
The REopt errors were/are not exposed on the command line.
Adding a bit more puts statement so we can easily distinguish the following error (which we have a documented solution for):

 SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)


We should review reopt_lite_api.rb to ensure we are exposing as much error information as we can for future troubleshooting.