### PR TITLE
Upgrade to OpenStudio 3.8 & Ruby 3.2

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global --add safe.directory '*'
       - name: Update gems
         run: |
-          bundle update
+          bundle install
           bundle exec certified-update
       - name: Run Rspec
         run: bundle exec rspec

--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -21,7 +21,7 @@ jobs:
     # https://github.com/rbenv/ruby-build/discussions/1940
     runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.7.0
+      image: docker://nrel/openstudio:3.8.0
     steps:
       - uses: actions/checkout@v4
       - name: set git config options

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../OpenStudio-extension-gem')
 #   gem 'openstudio-extension', path: '../OpenStudio-extension-gem'
 # elsif allow_local
-#   gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
+  gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'dont_raise_when_mistmatch'
 # end
 #
 # if allow_local && File.exist?('../openstudio-common-measures-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,9 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../OpenStudio-extension-gem')
 #   gem 'openstudio-extension', path: '../OpenStudio-extension-gem'
 # elsif allow_local
-  gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'dont_raise_when_mistmatch'
+# gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
+# else
+# gem 'openstudio-extension', '~> 0.8.1'
 # end
 #
 # if allow_local && File.exist?('../openstudio-common-measures-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,11 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-scenario-gem')
 #  gem 'urbanopt-scenario', path: '../urbanopt-scenario-gem'
 # elsif allow_local
-# gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'reopt-v3'
+gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'os38'
 # end
+
+# Temporary! Remove this once reporting-gem is merged/released
+gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'os38'
 
 # if allow_local && File.exists?('../urbanopt-geojson-gem')
 #   gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'

--- a/docs/schemas/reopt-output-schema.md
+++ b/docs/schemas/reopt-output-schema.md
@@ -1,6 +1,6 @@
 # REopt Lite Outputs Schema
 
-When the gem calls the REopt Lite APUI it recieves the following complete set of results described in the data dictionary below. Only those needed to update a Feature or Scenario Report's distributed_generation attibute set and timeseries CSV are pulled from the reponse and transferred to the Feature or Scenario Report. You may choose to modify the code to include more or less of the full REopt Lite response.
+When the gem calls the REopt Lite APUI it receives the following complete set of results described in the data dictionary below. Only those needed to update a Feature or Scenario Report's distributed_generation attribute set and timeseries CSV are pulled from the response and transferred to the Feature or Scenario Report. You may choose to modify the code to include more or less of the full REopt Lite response.
 
 ## Data Dictionary
 <ReoptOutputSchema />

--- a/lib/urbanopt/reopt/feature_report_adapter.rb
+++ b/lib/urbanopt/reopt/feature_report_adapter.rb
@@ -151,7 +151,7 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to update from a \REopt reponse hash.
+      # * +feature_report+ - _URBANopt::Reporting::DefaultReports::FeatureReport_ - FeatureReport to update from a \REopt response hash.
       # * +reopt_output+ - _Hash_ - A reponse hash from the \REopt API to use in overwriting FeatureReport technology sizes, costs and dispatch strategies.
       # * +timeseries_csv_path+ - _String_ - Optional. The path to a file at which a new timeseries CSV will be written. If not provided a file is created based on the run_uuid of the \REopt optimization task.
       #

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -16,7 +16,7 @@ module URBANopt # :nodoc:
   module REopt  # :nodoc:
     class REoptLiteAPI
       ##
-      # \REoptLiteAPI manages submitting optimization tasks to the \REopt API  and recieving results.
+      # \REoptLiteAPI manages submitting optimization tasks to the \REopt API  and receiving results.
       # Results can either be sourced from the production \REopt API with an API key from developer.nrel.gov, or from
       # a version running at localhost.
       ##
@@ -55,7 +55,7 @@ module URBANopt # :nodoc:
       #
       # * +run_uuid+ - _String_ - Unique run_uuid obtained from the \REopt job submittal URL for a specific optimization task.
       #
-      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt results endpoint for a specifc optimization task.
+      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt results endpoint for a specific optimization task.
       ##
       def uri_results(run_uuid) # :nodoc:
         if @use_localhost
@@ -73,7 +73,7 @@ module URBANopt # :nodoc:
       #
       # * +run_uuid+ - _String_ - Resilience statistics for a unique run_uuid obtained from the \REopt job submittal URL for a specific optimization task.
       #
-      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt resilience statistics endpoint for a specifc optimization task.
+      # [*return:*] _URI_ - Returns URI object for use in calling the \REopt resilience statistics endpoint for a specific optimization task.
       ##
       def uri_resilience(run_uuid) # :nodoc:
         if @use_localhost
@@ -133,7 +133,7 @@ module URBANopt # :nodoc:
       #
       # * +data+ - _Hash_ - Default \REopt formatted post containing at least all the required parameters.
       #
-      # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
+      # [*return:*] _Bool_ - Returns true if the post succeeds. Otherwise returns false.
       ##
       def check_connection(data)
         header = { 'Content-Type' => 'application/json' }
@@ -166,7 +166,7 @@ module URBANopt # :nodoc:
       # * +reopt_input+ - _Hash_ - \REopt formatted post containing at least required parameters.
       # * +filename+ - _String_ - Path to file that will be created containing the full \REopt response.
       #
-      # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
+      # [*return:*] _Bool_ - Returns true if the post succeeds. Otherwise returns false.
       ##
       def resilience_request(run_uuid, filename)
         if File.directory? filename
@@ -246,7 +246,7 @@ module URBANopt # :nodoc:
       # * +reopt_input+ - _Hash_ - \REopt formatted post containing at least required parameters.
       # * +filename+ - _String_ - Path to file that will be created containing the full \REopt response.
       #
-      # [*return:*] _Bool_ - Returns true if the post succeeeds. Otherwise returns false.
+      # [*return:*] _Bool_ - Returns true if the post succeeds. Otherwise returns false.
       ##
       def reopt_request(reopt_input, filename)
         description = reopt_input[:description]

--- a/lib/urbanopt/reopt/reopt_lite_api.rb
+++ b/lib/urbanopt/reopt/reopt_lite_api.rb
@@ -8,7 +8,6 @@ require 'openssl'
 require 'uri'
 require 'json'
 require 'securerandom'
-require 'certified'
 require_relative '../../../developer_nrel_key'
 require 'urbanopt/reopt/reopt_logger'
 
@@ -112,11 +111,11 @@ module URBANopt # :nodoc:
             end
             tries = max_tries
           rescue StandardError => e
-            @@logger.debug("error from REopt API: #{e}")
+            @@logger.warn("error from REopt API: #{e}")
             if tries + 1 < max_tries
               @@logger.debug('trying again...')
             else
-              @@logger.debug('max tries reached!')
+              @@logger.warn('max tries reached!')
               return result
             end
             tries += 1

--- a/lib/urbanopt/reopt/reopt_logger.rb
+++ b/lib/urbanopt/reopt/reopt_logger.rb
@@ -12,7 +12,7 @@ module URBANopt
     # Set Logger::DEBUG for development
     @@reopt_logger.level = Logger::WARN
     ##
-    # Definining class variable "@@logger" to log errors, info and warning messages.
+    # Defining class variable "@@logger" to log errors, info and warning messages.
     def self.reopt_logger
       @@reopt_logger
     end

--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -182,7 +182,7 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +feature_reports+ - _Array_ -  An array of _URBANopt::Reporting::DefaultReports::FeatureReport_ objetcs which will each be used to create (and are subsquently updated by) a \REopt opimization response.
+      # * +feature_reports+ - _Array_ -  An array of _URBANopt::Reporting::DefaultReports::FeatureReport_ objects which will each be used to create (and are subsequently updated by) a \REopt opimization response.
       # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the feature_reports array.
       # * +reopt_output_files+ - _Array_ - Optional. A array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the feature_reports array.
       # * +timeseries_csv_path+ - _Array_ - Optional. A array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the feature_reports array.
@@ -276,7 +276,7 @@ module URBANopt # :nodoc:
       #
       # [*parameters:*]
       #
-      # * +scenario_report+ - _Array_ -  A _URBANopt::Reporting::DefaultReports::ScenarioReport_ which will each be used to create (and is subsquently updated by) \REopt opimization responses for each of its FeatureReports.
+      # * +scenario_report+ - _Array_ -  A _URBANopt::Reporting::DefaultReports::ScenarioReport_ which will each be used to create (and is subsequently updated by) \REopt opimization responses for each of its FeatureReports.
       # * +reopt_assumptions_hashes+ - _Array_ - Optional. An array of \REopt formatted hashes containing default parameters (i.e. utility rate, escalation rate) which will be updated by the ScenarioReport (i.e. location, roof availability). The number and order of the hashes should match the array in ScenarioReport.feature_reports.
       # * +reopt_output_files+ - _Array_ - Optional. An array of paths to files at which REpopt responses will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.
       # * +feature_report_timeseries_csv_paths+ - _Array_ - Optional. An array of paths to files at which the new timeseries CSV for the FeatureReports will be saved. The number and order of the paths should match the array in ScenarioReport.feature_reports.

--- a/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
+++ b/lib/urbanopt/reopt/reopt_schema/reopt_input_schema.json
@@ -101,7 +101,7 @@
 					"min": 0,
 					"max": 1000000.0,
 					"type": "number",
-					"description": "Value placed on unmet site load during grid outages. Units are US dollars per unmet kilowatt-hour. The value of lost load (VoLL) is used to determine the avoided outage costs by multiplying VoLL [$/kWh] with the average number of hours that the critical load can be met by the energy system (determined by simulating outages occuring at every hour of the year), and multiplying by the mean critical load."
+					"description": "Value placed on unmet site load during grid outages. Units are US dollars per unmet kilowatt-hour. The value of lost load (VoLL) is used to determine the avoided outage costs by multiplying VoLL [$/kWh] with the average number of hours that the critical load can be met by the energy system (determined by simulating outages occurring at every hour of the year), and multiplying by the mean critical load."
 				},
 				"analysis_years": {
 					"default": 20,
@@ -711,7 +711,7 @@
 					"min": 0,
 					"max": 1,
 					"type": "number",
-					"description": "Fraction of upfront project costs to depreciate under MACRS in year one in addtion to scheduled depreciation"
+					"description": "Fraction of upfront project costs to depreciate under MACRS in year one in addition to scheduled depreciation"
 				},
 				"inverter_replacement_year": {
 					"default": 10,

--- a/lib/urbanopt/reopt/utilities.rb
+++ b/lib/urbanopt/reopt/utilities.rb
@@ -36,7 +36,7 @@ def convert_powerflow_resolution(timeseries_kw, original_res, destination_res)
     current_origin_idx = 0 # current integer index of the origin timeseries
     (0..(8760 * destination_res - 1)).each do |ts|
       next_stopping_ts = current_origin_ts + stepping_interval # stop at the next destination interval
-      total_power = [] # create to store wieghted origin timestep values to average
+      total_power = [] # create to store weighted origin timestep values to average
       while current_origin_ts != next_stopping_ts
         next_origin_ts_int = Integer(current_origin_ts) + 1
         # Calc next stopping point that will being you to the next origin or destination time step
@@ -61,7 +61,7 @@ def convert_powerflow_resolution(timeseries_kw, original_res, destination_res)
     # Timesteps will be expanded, i.e. 8760 -> 35040
 
     # This algorithm works by stepping along the destination timeseries. Steps are made to the next
-    # destination or origin breakpoint, and at each step the propotional amount of the origin stepped
+    # destination or origin breakpoint, and at each step the proportional amount of the origin stepped
     # is added to the destination. For example, in in EX 1 below 4 steps are made each with adding the full amount of
     # the origin (1, 1, 2 and 2) since each in the destination overlaps perfectly with 2 origin
     # timesteps. In EX 2, the origin overlaps with the first 2 destination timesteps but the third

--- a/lib/urbanopt/reopt/version.rb
+++ b/lib/urbanopt/reopt/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt # :nodoc:
   module REopt # :nodoc:
-    VERSION = '0.12.0'.freeze
+    VERSION = '0.13.0'.freeze
   end
 end

--- a/spec/cli_openssl_test.rb
+++ b/spec/cli_openssl_test.rb
@@ -1,9 +1,0 @@
-# *********************************************************************************
-# URBANopt (tm), Copyright (c) Alliance for Sustainable Energy, LLC.
-# See also https://github.com/urbanopt/urbanopt-reopt-gem/blob/develop/LICENSE.md
-# *********************************************************************************
-
-require 'urbanopt/reopt'
-
-api = URBANopt::REopt::REoptLiteAPI.new
-api.check_connection

--- a/spec/tests/urbanopt_reopt_spec.rb
+++ b/spec/tests/urbanopt_reopt_spec.rb
@@ -5,9 +5,6 @@
 
 require_relative '../spec_helper'
 require_relative '../../developer_nrel_key'
-require 'certified'
-require 'fileutils'
-require 'pathname'
 
 RSpec.describe URBANopt::REopt do
   scenario_dir = Pathname(__FILE__).dirname.parent / 'run' / 'example_scenario'

--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
   spec.required_ruby_version = '3.2.2'
 
-  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  # spec.add_dependency 'openstudio-extension', '~> 0.8.0'
   # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2
   spec.add_dependency 'matrix', '~> 0.4.2'
   spec.add_dependency 'certified', '~> 1'

--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   # spec.add_dependency 'openstudio-extension', '~> 0.8.0'
   # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2
   spec.add_dependency 'matrix', '~> 0.4.2'
-  spec.add_dependency 'certified', '~> 1'
   # spec.add_dependency 'urbanopt-scenario', '~> 0.12.0'
 
   spec.add_development_dependency 'rspec', '~> 3.13'

--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -21,17 +21,17 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  # We support exactly Ruby v3.2.2 because os-extension requires bundler==2.4.10 and that requires Ruby 3.2.2: https://stdgems.org/bundler/
+  # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
+  spec.required_ruby_version = '3.2.2'
 
-  spec.required_ruby_version = '~> 2.7.0'
-
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '~> 1.15.0'
-  spec.add_development_dependency 'simplecov', '~> 0.18.2'
-  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
-  spec.add_development_dependency 'openstudio-extension', '~> 0.7.1'
-
+  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2
+  spec.add_dependency 'matrix', '~> 0.4.2'
   spec.add_dependency 'certified', '~> 1'
-  spec.add_dependency 'urbanopt-scenario', '~> 0.12.0'
+  # spec.add_dependency 'urbanopt-scenario', '~> 0.12.0'
+
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
 end

--- a/urbanopt-reopt.gemspec
+++ b/urbanopt-reopt.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
   spec.required_ruby_version = '3.2.2'
 
-  # spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  spec.add_dependency 'openstudio-extension', '~> 0.8.1'
   # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2
   spec.add_dependency 'matrix', '~> 0.4.2'
   # spec.add_dependency 'urbanopt-scenario', '~> 0.12.0'


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

The current version of OpenStudio, [v3.8](https://github.com/NREL/OpenStudio/releases) includes a major breaking change to move from Ruby 2.7.2 to Ruby 3.2.2.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
