### PR TITLE
NLR updates and API URL change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@
 # test files
 spec/files/run/baseline_scenario_ghe/reopt_ghp/
 
-developer_api_key.rb
+developer_nrel_key.rb
+
 # rspec failure tracking
 .rspec_status
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 spec/files/run/baseline_scenario_ghe/reopt_ghp/
 
 developer_nrel_key.rb
+developer_api_key.rb
 
 # rspec failure tracking
 .rspec_status

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # test files
 spec/files/run/baseline_scenario_ghe/reopt_ghp/
 
-developer_nrel_key.rb
+developer_api_key.rb
 # rspec failure tracking
 .rspec_status
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ For further questions or information:
 
 - Ben Polly\
 URBANopt Project Management\
-ben.polly@nrel.gov\
+ben.polly@nlr.gov\
 (303) 384-7429
 
 URBANopt is funded by the U.S. Department of Energy (DOE) and managed by the National Laboratory of the Rockies (NLR).

--- a/RDOC_MAIN.md
+++ b/RDOC_MAIN.md
@@ -1,11 +1,11 @@
 # **URBANopt REopt Gem**
 
-The **URBANopt™ REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nrel.gov/tool) decision support platform.
-REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The **URBANopt™ REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nlr.gov/tool) decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nlr.gov/docs/energy-optimization/reopt/v2/](https://developer.nlr.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 See the [example project](https://github.com/urbanopt/urbanopt-example-reopt-project.git) for more infomation about usage of this gem.
 
-<b>Note:</b> This module requires an API Key from the [NLR Developer Network](https://developer.nrel.gov/)
+<b>Note:</b> This module requires an API Key from the [NLR Developer Network](https://developer.nlr.gov/)
 
 ## Installation
 
@@ -83,7 +83,7 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 ```
 
-The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nlr.gov/docs/energy-optimization/reopt/v2/](https://developer.nlr.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 <b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
@@ -110,8 +110,8 @@ timeseries_output_file = File.join(feature_report.directory_name, 'feature_repor
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
@@ -145,8 +145,8 @@ end
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
@@ -157,9 +157,9 @@ updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_repo
 
 First, check out the repository (i.e. git clone this repo).
 
-Next, obtain a developer.nrel.gov API key from the [NLR Developer Network](https://developer.nrel.gov/]). Copy and paste your key in to the _developer_nrel_key_._rb_ file then save the file:
+Next, obtain a developer.nlr.gov API key from the [NLR Developer Network](https://developer.nlr.gov/]). Copy and paste your key in to the _developer_api_key_._rb_ file then save the file:
 
-    DEVELOPER_NREL_KEY = '<insert your key here>'
+    DEVELOPER_API_KEY = '<insert your key here>'
 
 Finally, execute:
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Coverage Status](https://coveralls.io/repos/github/urbanopt/urbanopt-reopt-gem/badge.svg?branch=develop)](https://coveralls.io/github/urbanopt/urbanopt-reopt-gem?branch=develop)
 [![nightly_build](https://github.com/urbanopt/urbanopt-reopt-gem/actions/workflows/nightly_ci_build.yml/badge.svg)](https://github.com/urbanopt/urbanopt-reopt-gem/actions/workflows/nightly_ci_build.yml)
 
-The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nrel.gov/tool) decision support platform.
-REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nlr.gov/tool) decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nlr.gov/docs/energy-optimization/reopt/v2/](https://developer.nlr.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 See the [example project](https://github.com/urbanopt/urbanopt-example-geojson-reopt-project) for more infomation about usage of this gem.
 
 <b>Note:</b> this module requires an API Key from the
-[NLR Developer Network](https://developer.nrel.gov/)
+[NLR Developer Network](https://developer.nlr.gov/)
 
 [RDoc Documentation](https://urbanopt.github.io/urbanopt-reopt-gem/)
 
@@ -88,7 +88,7 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 
 
-The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nlr.gov/docs/energy-optimization/reopt/v2/">https://developer.nlr.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
 
 <b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
@@ -115,8 +115,8 @@ timeseries_output_file = File.join(feature_report.directory_name, 'feature_repor
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
@@ -149,8 +149,8 @@ end
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
@@ -161,9 +161,60 @@ updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_repo
 
 First, check out the repository (i.e. git clone this repo).
 
-Next, obtain a developer.nrel.gov API key from the [NLR Developer Network](https://developer.nrel.gov/]). Copy and paste your key in to the _developer_nrel_key_._rb_ file then save the file:
+Next, obtain a developer.nlr.gov API key from the [NLR Developer Network](https://developer.nlr.gov/]). Copy and paste your key in to the _developer_api_key.rb_ file then save the file:
 
-    DEVELOPER_NREL_KEY = '<insert your key here>'
+    DEVELOPER_API_KEY = '<insert your key here>'
+
+## Configuration
+
+### API Key Setup
+
+The gem supports multiple ways to provide your developer API key:
+
+1. **Environment Variable (Recommended):**
+   ```bash
+   export GEM_DEVELOPER_KEY=your_api_key_here
+   # Then API instances automatically use this key
+   api = URBANopt::REopt::REoptAPI.new()
+   ```
+
+2. **Direct Parameter:**
+   ```ruby
+   api = URBANopt::REopt::REoptAPI.new('your_api_key_here')
+   ```
+
+3. **Edit developer_api_key.rb file:**
+   ```ruby
+   DEVELOPER_API_KEY = 'your_api_key_here'
+   ```
+
+### Environment Variables
+
+You can customize the REopt API endpoints using environment variables:
+
+- `REOPT_BASE_URL`: Override the default base URL for all REopt API endpoints.
+  - Default: `https://developer.nlr.gov/api/reopt/v3`
+  - Example: `export REOPT_BASE_URL=https://test.example.com/api/reopt/v3`
+
+- `GEM_DEVELOPER_KEY`: Set the developer API key via environment variable instead of editing the source file.
+  - Example: `export GEM_DEVELOPER_KEY=your_api_key_here`
+  - This automatically becomes available as `DEVELOPER_API_KEY` constant in the code
+
+### Localhost Development
+
+For development against a local REopt instance, use the `REOPT_BASE_URL` environment variable:
+
+```bash
+# Use localhost (no API key needed)
+export REOPT_BASE_URL=http://127.0.0.1:8000/v3
+
+# Then create API instances normally
+api = URBANopt::REopt::REoptAPI.new()
+```
+
+Note: When using custom URLs via `REOPT_BASE_URL`, API keys are automatically bypassed for non-official endpoints.
+
+## Running Tests
 
 Finally, execute:
 

--- a/developer_api_key.rb
+++ b/developer_api_key.rb
@@ -3,4 +3,4 @@
 # See also https://github.com/urbanopt/urbanopt-reopt-gem/blob/develop/LICENSE.md
 # *********************************************************************************
 
-DEVELOPER_NREL_KEY = (ENV['GEM_DEVELOPER_KEY'] || '< your key here https://developer.nrel.gov/signup >')
+DEVELOPER_API_KEY = (ENV['GEM_DEVELOPER_KEY'] || '< your key here https://developer.nlr.gov/signup >')

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 ### <StaticLink target="\_blank" href="rdoc/">Rdocs</StaticLink>
 
-The **URBANopt<sup>&trade;</sup> REopt Gem** extends a **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the <StaticLink target="\_blank" href="https://reopt.nrel.gov/tool">REopt</StaticLink> decision support platform.
-REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
+The **URBANopt<sup>&trade;</sup> REopt Gem** extends a **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the <StaticLink target="\_blank" href="https://reopt.nlr.gov/tool">REopt</StaticLink> decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See <StaticLink target="\_blank" href="https://developer.nlr.gov/docs/energy-optimization/reopt/v2/">https://developer.nlr.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
 
 The REopt Gem accomplishes three basic functions (described more below in the _Functionality_ section):
 
@@ -20,7 +20,7 @@ Moreover, the REopt Gem can be run in several modes, either on:
 
 See the <StaticLink target="\_blank" href="https://github.com/urbanopt/urbanopt-example-reopt-project.git">example project</StaticLink> for more infomation about usage of this gem.
 
-<b>Note:</b> This module requires an API Key from the <StaticLink target='blank' href="https://developer.nrel.gov/">NLR Developer Network</StaticLink>.
+<b>Note:</b> This module requires an API Key from the <StaticLink target='blank' href="https://developer.nlr.gov/">NLR Developer Network</StaticLink>.
 
 <StaticLink target="\_blank" href="https://urbanopt.github.io/urbanopt-reopt-gem/">RDoc Documentation</StaticLink>
 
@@ -99,7 +99,7 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 
 
-The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nrel.gov/docs/energy-optimization/reopt/v2/">https://developer.nrel.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See <StaticLink target="\_blank" href="https://developer.nlr.gov/docs/energy-optimization/reopt/v2/">https://developer.nlr.gov/docs/energy-optimization/reopt/v2/</StaticLink> for more detailed information on input parameters and default assumptions.
 
 <b>Note:</b> Required attributes for a REopt run include latitude and longitude, parsed from the Feature or Scenario Report attributes. If no utility rate is specified in your assumptions, then a constant rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
@@ -112,7 +112,7 @@ The code below shows how to run the REopt API on a single Feature Report hash us
 ```ruby
 require 'urbanopt/reopt'
 
-DEVELOPER_NREL_KEY = "" # <insert a valid API key from https://developer.nrel.gov/signup >
+DEVELOPER_API_KEY = "" # <insert a valid API key from https://developer.nlr.gov/signup >
 
 #Load a Feature Report Hash
 feature_reports_hash = {} # <insert a valid Feature Report hash here with latitude and longitude filled in>
@@ -129,8 +129,8 @@ timeseries_output_file = File.join(feature_report.directory_name, 'feature_repor
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
@@ -140,7 +140,7 @@ updated_feature_report = reopt_post_processor.run_feature_report(feature_report,
 More commonly, this gem can be used to run REopt a collection of features stored in a Scenario Report as show here:
 ```ruby
 require 'urbanopt/reopt'
-DEVELOPER_NREL_KEY = "" # <insert a valid API key from https://developer.nrel.gov/signup >
+DEVELOPER_API_KEY = "" # <insert a valid API key from https://developer.nlr.gov/signup >
 
 #Create a Scenario Report
 scenario_report = URBANopt::Reporting::DefaultReports::ScenarioReport.new({:directory_name => File.join(File.dirname(__FILE__), 'run/example_scenario'), :timeseries_csv => {:path => File.join(File.dirname(__FILE__), 'run/example_scenario/timeseries.csv') }})
@@ -165,8 +165,8 @@ end
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), 'files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
@@ -177,9 +177,9 @@ updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_repo
 
 First, check out the repository (i.e. git clone this repo).
 
-Next, obtain a developer.nrel.gov API key from the [NLR Developer Network](https://developer.nrel.gov/]). Copy and paste your key in to the _developer_nrel_key_._rb_ file then save the file:
+Next, obtain a developer.nlr.gov API key from the [NLR Developer Network](https://developer.nlr.gov/]). Copy and paste your key in to the _developer_api_key_._rb_ file then save the file:
 
-    DEVELOPER_NREL_KEY = '<insert your key here>'
+    DEVELOPER_API_KEY = '<insert your key here>'
 
 Finally, execute:
 

--- a/docs/schemas/reopt-input-schema.md
+++ b/docs/schemas/reopt-input-schema.md
@@ -1,6 +1,6 @@
-# REopt Lite Inputs Schema
+# REopt Inputs Schema
 
-The following shows the complete set of inputs to the REopt Lite AP which is called internally by the REopt Gem. You may refer to the data dictionary below in creating similarly formatted .json files containing alternatives to the defaults for optional parameters (i.e. specific utility rate, installed cost assumptions, solar PV losses, ...). The URBANopt REopt Gem will overwrite latitude, longitude, land_acres, roof_squarefeet, and loads_kw where possible from attributes of a Scenario Report and FeatureReports.
+The following shows the complete set of inputs to the REopt API which is called internally by the REopt Gem. You may refer to the data dictionary below in creating similarly formatted .json files containing alternatives to the defaults for optional parameters (i.e. specific utility rate, installed cost assumptions, solar PV losses, ...). The URBANopt REopt Gem will overwrite latitude, longitude, land_acres, roof_squarefeet, and loads_kw where possible from attributes of a Scenario Report and FeatureReports.
 
 ## Data Dictionary
 
@@ -8,7 +8,7 @@ The following shows the complete set of inputs to the REopt Lite AP which is cal
 
 ## Required Inputs
 
-The only required parameters to the REopt Lite API (called internally by the gem) are:
+The only required parameters to the REopt API (called internally by the gem) are:
 - *latitude*
 - *longitude*
 - *urdb_response* OR one of the following sets:
@@ -24,7 +24,7 @@ The only required parameters to the REopt Lite API (called internally by the gem
 
 The gem sources *latitude*, *longitude* and *loads_kw* from a Feature or Scenario Report directly. If no specific *urdb_response* or *urdb_label* is specified as an custom assumption (see below), then a constant rate of $0.13/kWh with no demand charge is provided by the gem as a default to the REopt API.
 
-Otherwise, all non-required input parameters will be filled in with default values unless otherwise specified. For an example of a minimally viable REopt Lite input, see:
+Otherwise, all non-required input parameters will be filled in with default values unless otherwise specified. For an example of a minimally viable REopt input, see:
 
 
 ```

--- a/docs/schemas/reopt-output-schema.md
+++ b/docs/schemas/reopt-output-schema.md
@@ -1,6 +1,6 @@
-# REopt Lite Outputs Schema
+# REopt Outputs Schema
 
-When the gem calls the REopt Lite APUI it receives the following complete set of results described in the data dictionary below. Only those needed to update a Feature or Scenario Report's distributed_generation attribute set and timeseries CSV are pulled from the response and transferred to the Feature or Scenario Report. You may choose to modify the code to include more or less of the full REopt Lite response.
+When the gem calls the REopt API it receives the following complete set of results described in the data dictionary below. Only those needed to update a Feature or Scenario Report's distributed_generation attribute set and timeseries CSV are pulled from the response and transferred to the Feature or Scenario Report. You may choose to modify the code to include more or less of the full REopt response.
 
 ## Data Dictionary
 <ReoptOutputSchema />
@@ -8,7 +8,7 @@ When the gem calls the REopt Lite APUI it receives the following complete set of
 ## Updated from the Data Dictionary
 
 ### Distributed Generation Attributes
-The REopt Lite API updates the distributed_generation attributes of a Scenario or Feature Report as shown in an example below.
+The REopt API updates the distributed_generation attributes of a Scenario or Feature Report as shown in an example below.
 
 ```
 	"distributed_generation": {
@@ -35,7 +35,7 @@ The REopt Lite API updates the distributed_generation attributes of a Scenario o
 ```
 
 ### Timeseries CSV
-REopt Lite API responses also map dispatches to the following columns in an updated timeseries CSV for a Feature or Scenario Report.
+REopt API responses also map dispatches to the following columns in an updated timeseries CSV for a Feature or Scenario Report.
 
 |            output                        |  unit   |
 | -----------------------------------------| ------- |
@@ -62,5 +62,5 @@ REopt Lite API responses also map dispatches to the following columns in an upda
 <style type="text/css">
 .content { max-width: 1200px !important; }
 span.default { color: yellow !important; }
-.description { color: #E0E0E0		 !important; }
+.description { color: #E0E0E0 !important; }
 </style>

--- a/index.md
+++ b/index.md
@@ -1,11 +1,11 @@
 # **URBANopt REopt Gem**
 
-The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nrel.gov/tool) decision support platform.
-REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The **URBANopt<sup>&trade;</sup> REopt Gem** extends **URBANopt::Reporting::DefaultReports::ScenarioReport** and **URBANopt::Reporting::DefaultReports::FeatureReport** with the ability to derive cost-optimal distributed energy resource (DER) technology sizes and annual dispatch strageties via the [REopt](https://reopt.nlr.gov/tool) decision support platform.
+REopt is a technoeconomic model which leverages mixed integer linear programming to identify the cost-optimal sizing of solar PV, Wind, Storage and/or diesel generation given an electric load profile, a utility rate tariff and other technoeconomic parameters. See [https://developer.nlr.gov/docs/energy-optimization/reopt/v2/](https://developer.nlr.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
 
 See the [example project](https://github.com/urbanopt/urbanopt-example-reopt-project.git) for more infomation about usage of this gem.
 
-<b>Note:</b> This module requires an API Key from the [NLR Developer Network](https://developer.nrel.gov/)
+<b>Note:</b> This module requires an API Key from the [NLR Developer Network](https://developer.nlr.gov/)
 
 ## Installation
 
@@ -83,7 +83,7 @@ Moreover, the following optimal dispatch fields are added to its timeseries CSV.
 | ElectricityProduced:Wind:ToGrid          | kWh     |
 ```
 
-The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer.nrel.gov/docs/energy-optimization/reopt/v2/](https://developer.nrel.gov/docs/energy-optimization/reopt/v2/) for more detailed information on input parameters and default assumptions.
+The REopt has default values for all non-required input parameters that are used unless the user specifies custom assumptions. See [https://developer..gov/docs/energy-optimization/reopt/v3/](https://developer.nlr.gov/docs/energy-optimization/reopt/v3/) for more detailed information on input parameters and default assumptions.
 
 <b>Note:</b> Required attributes for a REopt run include latitude and longitude. If no utility rate is specified in your REopt assumption settings, then a constant default rate of $0.13 is assumed without demand charges. Also, by default, only solar PV and storage are considered in the analysis (i.e. Wind and Generators are excluded from consideration).
 
@@ -110,8 +110,8 @@ timeseries_output_file = File.join(feature_report.directory_name, 'feature_repor
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor to update the feature's distributed generation attributes and timeseries CSV.
 updated_feature_report = reopt_post_processor.run_feature_report(feature_report,reopt_assumptions_file,reopt_output_file,timeseries_output_file)
@@ -145,8 +145,8 @@ end
 #Specify non-default REopt assumptions, saved in JSON format, to be used in calling the API
 reopt_assumptions_file = File.join(File.dirname(__FILE__), '../files/reopt_assumptions_basic.json')
 
-#Create a REopt Post Processor to call the API, note you will need a Developer.nrel.gov API key in this step
-reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
+#Create a REopt Post Processor to call the API, note you will need a Developer.nlr.gov API key in this step
+reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_API_KEY)
 
 #Call REopt with the post processor once on the sceanrio's aggregated load to update the scenario's distributed generation attributes and timeseries CSV.
 updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_report)
@@ -157,9 +157,9 @@ updated_scenario_report = reopt_post_processor.run_scenario_report(scenario_repo
 
 First, check out the repository (i.e. git clone this repo).
 
-Next, obtain a developer.nrel.gov API key from the [NLR Developer Network](https://developer.nrel.gov/]). Copy and paste your key in to the _developer_nrel_key_._rb_ file then save the file:
+Next, obtain a developer.nlr.gov API key from the [NLR Developer Network](https://developer.nlr.gov/]). Copy and paste your key in to the _developer_api_key_._rb_ file then save the file:
 
-    DEVELOPER_NREL_KEY = '<insert your key here>'
+    DEVELOPER_API_KEY = '<insert your key here>'
 
 Finally, execute:
 

--- a/lib/urbanopt/reopt.rb
+++ b/lib/urbanopt/reopt.rb
@@ -4,7 +4,8 @@
 # *********************************************************************************
 
 require 'urbanopt/reopt/extension'
-require 'urbanopt/reopt/reopt_lite_api'
+require 'urbanopt/reopt/url_config'
+require 'urbanopt/reopt/reopt_api'
 require 'urbanopt/reopt/feature_report_adapter'
 require 'urbanopt/reopt/scenario_report_adapter'
 require 'urbanopt/reopt/reopt_post_processor'

--- a/lib/urbanopt/reopt/reopt_api.rb
+++ b/lib/urbanopt/reopt/reopt_api.rb
@@ -8,43 +8,47 @@ require 'openssl'
 require 'uri'
 require 'json'
 require 'securerandom'
-require_relative '../../../developer_nrel_key'
+require_relative '../../../developer_api_key'
 require 'urbanopt/reopt/reopt_logger'
+require 'urbanopt/reopt/url_config'
 
 module URBANopt # :nodoc:
   module REopt  # :nodoc:
-    class REoptLiteAPI
+    class REoptAPI
       ##
-      # \REoptLiteAPI manages submitting optimization tasks to the \REopt API  and receiving results.
-      # Results can either be sourced from the production \REopt API with an API key from developer.nrel.gov, or from
-      # a version running at localhost.
+      # \REoptAPI manages submitting optimization tasks to the \REopt API  and receiving results.
+      # Results can be sourced from the production \REopt API with an API key or from
+      # custom endpoints via the REOPT_BASE_URL environment variable.
       ##
       #
       # [*parameters:*]
       #
-      # * +use_localhost+ - _Bool_ - If this is true, requests will be sent to a version of the \REopt API running on localhost. Default is false, such that the production version of \REopt is accessed.
-      # * +nrel_developer_key+ - _String_ - API key used to access the \REopt APi. Required only if localhost is false. Obtain from https://developer.nrel.gov/signup/
+      # * +api_key+ - _String_ - API key used to access the \REopt API. Required only for developer.nlr.gov and developer.nlr.gov endpoints. Obtain from https://developer.nlr.gov/signup/
       ##
-      def initialize(nrel_developer_key = nil, use_localhost = false)
-        @use_localhost = use_localhost
-        if @use_localhost
-          @uri_submit = URI.parse('http//:127.0.0.1:8000/v3/job/')
-          @uri_submit_outagesimjob = URI.parse('http://127.0.0.1:8000/v3/erp/')
+      def initialize(api_key = nil)
 
-        else
-          if [nil, '', '<insert your key here>'].include? nrel_developer_key
-            if [nil, '', '<insert your key here>'].include? DEVELOPER_NREL_KEY
-              raise 'A developer.nrel.gov API key is required. Please see https://developer.nrel.gov/signup/ then update the file urbanopt-reopt-gem/developer_nrel_key.rb'
-            else
-              nrel_developer_key = DEVELOPER_NREL_KEY
+        # Handle API key validation for official developer URLs
+        if [nil, '', '<insert your key here>'].include? api_key
+          if [nil, '', '<insert your key here>'].include? DEVELOPER_API_KEY
+            # Check if we need an API key based on the URL that will be used
+            url_config_test = URLConfig.new
+            if url_config_test.requires_api_key?
+              raise 'A developer.nlr.gov API key is required. Please see https://developer.nlr.gov/signup/ then update the file developer_api_key.rb'
             end
+          else
+            api_key = DEVELOPER_API_KEY
           end
-          @nrel_developer_key = nrel_developer_key
-          @uri_submit = URI.parse("https://developer.nrel.gov/api/reopt/v3/job?api_key=#{@nrel_developer_key}")
-          @uri_submit_outagesimjob = URI.parse("https://developer.nrel.gov/api/reopt/v3/erp?api_key=#{@nrel_developer_key}")
-          # initialize @@logger
-          @@logger ||= URBANopt::REopt.reopt_logger
         end
+
+        # Initialize URL configuration
+        @url_config = URLConfig.new(api_key: api_key)
+
+        # Cache frequently used URIs
+        @uri_submit = @url_config.submit_uri
+        @uri_submit_outagesimjob = @url_config.erp_submit_uri
+
+        # initialize @@logger
+        @@logger ||= URBANopt::REopt.reopt_logger
       end
 
       ##
@@ -58,11 +62,7 @@ module URBANopt # :nodoc:
       # [*return:*] _URI_ - Returns URI object for use in calling the \REopt results endpoint for a specific optimization task.
       ##
       def uri_results(run_uuid) # :nodoc:
-        if @use_localhost
-          return URI.parse("http://127.0.0.1:8000/v3/job/#{run_uuid}/results")
-        end
-
-        return URI.parse("https://developer.nrel.gov/api/reopt/v3/job/#{run_uuid}/results?api_key=#{@nrel_developer_key}")
+        @url_config.results_uri(run_uuid)
       end
 
       ##
@@ -76,11 +76,7 @@ module URBANopt # :nodoc:
       # [*return:*] _URI_ - Returns URI object for use in calling the \REopt resilience statistics endpoint for a specific optimization task.
       ##
       def uri_resilience(run_uuid) # :nodoc:
-        if @use_localhost
-          return URI.parse("http://127.0.0.1:8000/v3/erp/#{run_uuid}/results")
-        end
-
-        return URI.parse("https://developer.nrel.gov/api/reopt/v3/erp/#{run_uuid}/results?api_key=#{@nrel_developer_key}")
+        @url_config.erp_results_uri(run_uuid)
       end
 
       def make_request(http, req, max_tries = 3)
@@ -89,7 +85,7 @@ module URBANopt # :nodoc:
         while tries < max_tries
           begin
             result = http.request(req)
-            # Result codes sourced from https://developer.nrel.gov/docs/errors/
+            # Result codes sourced from https://developer.nlr.gov/docs/errors/
             if result.code == '429'
               @@logger.fatal('Exceeded the REopt API limit of 300 requests per hour')
               puts 'Using the URBANopt CLI to submit a Scenario optimization counts as one request per scenario'
@@ -101,7 +97,7 @@ module URBANopt # :nodoc:
               tries += 1
               next
             elsif (result.code != '201') && (result.code != '200') # Anything in the 200s is success
-              @@logger.warn("REopt has returned a '#{result.code}' status code. Visit https://developer.nrel.gov/docs/errors/ for more status code information")
+              @@logger.warn("REopt has returned a '#{result.code}' status code. Visit https://developer.nlr.gov/docs/errors/ for more status code information")
               # display error messages
               json_res = JSON.parse(result.body, allow_nan: true)
               json_res['messages'].delete('warnings') if json_res['messages']['warnings']
@@ -138,9 +134,7 @@ module URBANopt # :nodoc:
       def check_connection(data)
         header = { 'Content-Type' => 'application/json' }
         http = Net::HTTP.new(@uri_submit.host, @uri_submit.port)
-        if !@use_localhost
-          http.use_ssl = true
-        end
+        @url_config.configure_ssl(http)
 
         post_request = Net::HTTP::Post.new(@uri_submit, header)
         post_request.body = ::JSON.generate(data, allow_nan: true)
@@ -182,20 +176,18 @@ module URBANopt # :nodoc:
         end
 
         # Add info message to logger
-        @@logger.info("Submitting Resilience Statistics job for #{run_uuid}")  
-        
+        @@logger.info("Submitting Resilience Statistics job for #{run_uuid}")
+
         # Format HTTP request
         header = { 'Content-Type' => 'application/json' }
         http = Net::HTTP.new(@uri_submit_outagesimjob.host, @uri_submit_outagesimjob.port)
-        if !@use_localhost
-          http.use_ssl = true
-        end
-        
+        @url_config.configure_ssl(http)
+
         # POST to erp endpoint
         post_request = Net::HTTP::Post.new(@uri_submit_outagesimjob, header)
         post = erp_assumptions_file
         post["reopt_run_uuid"] = run_uuid
-        
+
         post_request.body = ::JSON.generate(post, allow_nan: true)
 
         # Send the request
@@ -208,8 +200,7 @@ module URBANopt # :nodoc:
 
         # Get <erp_run_uuid>
         erp_run_uuid = JSON.parse(submit_response.body, allow_nan: true)['run_uuid']
-        
-        
+
         if File.directory? filename
           if erp_run_uuid.nil?
             erp_run_uuid = 'error'
@@ -232,9 +223,7 @@ module URBANopt # :nodoc:
         # Fetch Results, pass on <erp_run_uuid>
         uri = uri_resilience(erp_run_uuid)
         http = Net::HTTP.new(uri.host, uri.port)
-        if !@use_localhost
-          http.use_ssl = true
-        end
+        @url_config.configure_ssl(http)
 
         # Wait for the REopt API before attempting to GET results
         sleep 30
@@ -293,9 +282,7 @@ module URBANopt # :nodoc:
         # Format the request
         header = { 'Content-Type' => 'application/json' }
         http = Net::HTTP.new(@uri_submit.host, @uri_submit.port)
-        if !@use_localhost
-          http.use_ssl = true
-        end
+        @url_config.configure_ssl(http)
         post_request = Net::HTTP::Post.new(@uri_submit, header)
         post_request.body = ::JSON.generate(reopt_input, allow_nan: true)
 
@@ -332,9 +319,7 @@ module URBANopt # :nodoc:
         status = 'Optimizing...'
         uri = uri_results(run_uuid)
         http = Net::HTTP.new(uri.host, uri.port)
-        if !@use_localhost
-          http.use_ssl = true
-        end
+        @url_config.configure_ssl(http)
 
         get_request = Net::HTTP::Get.new(uri.request_uri)
 
@@ -343,7 +328,7 @@ module URBANopt # :nodoc:
           response = make_request(http, get_request)
 
           data = JSON.parse(response.body, allow_nan: true)
-          
+
           if !data['outputs']['PV']
             pv_sizes = 0
             sizes = 0

--- a/lib/urbanopt/reopt/reopt_ghp_api.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_api.rb
@@ -8,33 +8,35 @@ require 'openssl'
 require 'uri'
 require 'json'
 require 'securerandom'
-require_relative '../../../developer_nrel_key'
+require_relative '../../../developer_api_key'
 require 'urbanopt/reopt/reopt_logger'
+require 'urbanopt/reopt/url_config'
 
 module URBANopt # :nodoc:
   module REopt  # :nodoc:
-    class REoptLiteGHPAPI
+    class REoptGHPAPI
 
-        def initialize(reopt_input_file, nrel_developer_key = nil, reopt_output_file, use_localhost)
+        def initialize(reopt_input_file, api_key = nil, reopt_output_file)
 
             # Store developer key
-            if [nil, '', '<insert your key here>'].include? nrel_developer_key
-                if [nil, '', '<insert your key here>'].include? DEVELOPER_NREL_KEY
-                    raise 'A developer.nrel.gov API key is required. Please see https://developer.nrel.gov/signup/ then update the file urbanopt-reopt-gem/developer_nrel_key.rb'
+            if [nil, '', '<insert your key here>'].include? api_key
+                if [nil, '', '<insert your key here>'].include? DEVELOPER_API_KEY
+                    # Check if we need an API key based on the URL that will be used
+                    url_config_test = URLConfig.new
+                    if url_config_test.requires_api_key?
+                        raise 'A developer.nlr.gov API key is required. Please see https://developer.nlr.gov/signup/ then update the file developer_api_key.rb'
+                    end
                 else
-                    #Store the NLR developer key
-                    nrel_developer_key = DEVELOPER_NREL_KEY
+                    api_key = DEVELOPER_API_KEY
                 end
             end
 
-            @use_localhost = use_localhost
-            if @use_localhost
-                @root_url = "http://localhost:8000/v3"
-            else
-                @root_url = "https://developer.nrel.gov/api/reopt/v3"
-            end
-            # add REopt URL
-            @nrel_developer_key = nrel_developer_key
+            # Initialize URL configuration
+            @url_config = URLConfig.new(api_key: api_key)
+
+            # Store for backward compatibility
+            @root_url = @url_config.base_url
+            @api_key = api_key
             @reopt_input_file = reopt_input_file
             @reopt_output_file = reopt_output_file
             # initialize @@logger
@@ -46,15 +48,15 @@ module URBANopt # :nodoc:
         def get_api_results(run_id=nil)
 
             reopt_input_file = @reopt_input_file
-            nrel_developer_key = @nrel_developer_key
+            api_key = @api_key
             root_url = @root_url
             reopt_output_file = @reopt_output_file
 
             if run_id.nil?
-                run_id = get_run_uuid(reopt_input_file, nrel_developer_key, reopt_output_file)
+                run_id = get_run_uuid(reopt_input_file, api_key, reopt_output_file)
             end
             if !run_id.nil?
-                results_url = "#{@root_url}/job/#{run_id}/results/?api_key=#{nrel_developer_key}"
+                results_url = @url_config.url_for('job', run_uuid: run_id)
                 puts "This is results URL #{results_url}"
                 results = reopt_request(results_url)
 
@@ -69,12 +71,12 @@ module URBANopt # :nodoc:
             results
         end
 
-        def get_run_uuid(reopt_input_file, nrel_developer_key, root_url)
+        def get_run_uuid(reopt_input_file, api_key, root_url)
 
             reopt_input_file = @reopt_input_file
-            nrel_developer_key = @nrel_developer_key
+            api_key = @api_key
             root_url = @root_url
-            post_url = "#{root_url}/job/?api_key=#{nrel_developer_key}"
+            post_url = @url_config.url_for('job')
             puts "This is URL: #{post_url}"
             @@logger.info("Connecting to #{post_url}")
 

--- a/lib/urbanopt/reopt/reopt_ghp_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_post_processor.rb
@@ -14,12 +14,11 @@ require 'fileutils'
 module URBANopt # :nodoc:
   module REopt # :nodoc:
     class REoptGHPPostProcessor
-      def initialize(run_dir, system_parameter, modelica_result, reopt_ghp_assumptions = nil, nrel_developer_key = nil, localhost)
+      def initialize(run_dir, system_parameter, modelica_result, reopt_ghp_assumptions = nil, api_key = nil)
         # initialize @@logger
         @@logger ||= URBANopt::REopt.reopt_logger
 
-        @nrel_developer_key = nrel_developer_key
-        @localhost = localhost
+        @api_key = api_key
         @reopt_ghp_output_district = nil
         @reopt_ghp_output_building = []
         @reopt_ghp_assumptions_hash = nil
@@ -143,7 +142,7 @@ module URBANopt # :nodoc:
           # reopt_ghp_output_file
           reopt_output_file = File.join(reopt_ghp_output, "#{base_name}_output.json")
           # call the REopt API
-          api = URBANopt::REopt::REoptLiteGHPAPI.new(reopt_input_data, DEVELOPER_NREL_KEY, reopt_output_file, @localhost)
+          api = URBANopt::REopt::REoptGHPAPI.new(reopt_input_data, @api_key, reopt_output_file)
           api.get_api_results
 
         end

--- a/lib/urbanopt/reopt/reopt_post_processor.rb
+++ b/lib/urbanopt/reopt/reopt_post_processor.rb
@@ -21,18 +21,16 @@ module URBANopt # :nodoc:
       # * +scenario_report+ - _ScenarioReport_ - Optional. A scenario report that has been returned from the URBANopt::Reporting::ScenarioDefaultPostProcessor - used in creating default output file names in \REopt optimizations.
       # * +scenario_reopt_assumptions_file+ - _String_ - Optional. JSON file formatted for a \REopt analysis containing custom input parameters for optimizations at the Scenario Report level
       # * +reopt_feature_assumptions+ - _Array_ - Optional. A list of JSON file formatted for a \REopt analysis containing custom input parameters for optimizations at the Feature Report level. The order and number of files must match the Feature Reports in the scenario_report input.
-      # * +use_localhost+ - _Bool_ - If this is true, requests will be sent to a version of the \REopt API running on localhost. Default is false, such that the production version of \REopt is accessed.
-      # * +nrel_developer_key+ - _String_ - API used to access the \REopt APi. Required only if +localhost+ is false. Obtain from https://developer.nrel.gov/signup/
+      # * +api_key+ - _String_ - API key used to access the \REopt API. Required only for developer.nlr.gov and developer.nlr.gov endpoints. Obtain from https://developer.nlr.gov/signup/
       ##
-      def initialize(scenario_report, scenario_reopt_assumptions_file = nil, reopt_feature_assumptions = [], nrel_developer_key = nil, localhost = false, erp_assumptions_file = nil)
+      def initialize(scenario_report, scenario_reopt_assumptions_file = nil, reopt_feature_assumptions = [], api_key = nil, erp_assumptions_file = nil)
         # initialize @@logger
         @@logger ||= URBANopt::REopt.reopt_logger
 
         if reopt_feature_assumptions.nil?
           reopt_feature_assumptions = []
         end
-        @nrel_developer_key = nrel_developer_key
-        @localhost = localhost
+        @api_key = api_key
 
         @scenario_reopt_default_output_file = nil
         @scenario_timeseries_default_output_file = nil
@@ -101,7 +99,7 @@ module URBANopt # :nodoc:
       # [*return:*] _URBANopt::Reporting::DefaultReports::FeatureReport_ - Returns an updated FeatureReport
       ##
       def run_feature_report(feature_report:, reopt_assumptions_hash: nil, reopt_output_file: nil, timeseries_csv_path: nil, save_name: nil, run_resilience: false)
-        api = URBANopt::REopt::REoptLiteAPI.new(@nrel_developer_key, @localhost)
+        api = URBANopt::REopt::REoptAPI.new(@api_key)
         adapter = URBANopt::REopt::FeatureReportAdapter.new
 
         reopt_input = adapter.reopt_json_from_feature_report(feature_report, reopt_assumptions_hash)
@@ -160,7 +158,7 @@ module URBANopt # :nodoc:
             @scenario_erp_default_assumptions_hash = JSON.parse(file.read, symbolize_names: true)
           end
         end
-        api = URBANopt::REopt::REoptLiteAPI.new(@nrel_developer_key, @localhost)
+        api = URBANopt::REopt::REoptAPI.new(@api_key)
         adapter = URBANopt::REopt::ScenarioReportAdapter.new
 
         reopt_input = adapter.reopt_json_from_scenario_report(scenario_report, @scenario_reopt_default_assumptions_hash, community_photovoltaic)
@@ -245,7 +243,7 @@ module URBANopt # :nodoc:
           end
         end
 
-        api = URBANopt::REopt::REoptLiteAPI.new(@nrel_developer_key, @localhost)
+        api = URBANopt::REopt::REoptAPI.new(@api_key)
         feature_adapter = URBANopt::REopt::FeatureReportAdapter.new
         new_feature_reports = []
         feature_reports.each_with_index do |feature_report, idx|

--- a/lib/urbanopt/reopt/url_config.rb
+++ b/lib/urbanopt/reopt/url_config.rb
@@ -1,0 +1,152 @@
+# *********************************************************************************
+# URBANopt (tm), Copyright (c) Alliance for Energy Innovation, LLC.
+# See also https://github.com/urbanopt/urbanopt-reopt-gem/blob/develop/LICENSE.md
+# *********************************************************************************
+
+require 'uri'
+
+module URBANopt # :nodoc:
+  module REopt  # :nodoc:
+    ##
+    # URLConfig provides centralized configuration for all REopt API endpoint URLs.
+    # Supports environment variable overrides and default production URLs.
+    #
+    # Configuration priority:
+    # 1. REOPT_BASE_URL environment variable
+    # 2. Default production URL (developer.nlr.gov)
+    ##
+    class URLConfig
+      ##
+      # Default production base URL for REopt API
+      DEFAULT_BASE_URL = 'https://developer.nlr.gov/api/reopt/v3'
+
+      ##
+      # Initialize URL configuration
+      #
+      # [*parameters:*]
+      # * +api_key+ - _String_ - API key for endpoints that require authentication
+      ##
+      def initialize(api_key: nil)
+        @api_key = api_key
+        @base_url = determine_base_url
+      end
+
+      ##
+      # Get the base URL for REopt API
+      #
+      # [*return:*] _String_ - Base URL without trailing slash
+      ##
+      def base_url
+        @base_url
+      end
+
+      ##
+      # Check if this URL requires an API key
+      #
+      # [*return:*] _Bool_ - True if API key is required
+      ##
+      def requires_api_key?
+        @base_url.include?('developer.nlr.gov') || @base_url.include?('developer.nrel.gov')
+      end
+
+      ##
+      # Get URI for job submission endpoint
+      #
+      # [*return:*] _URI_ - Complete URI for job submission
+      ##
+      def submit_uri
+        url = "#{@base_url}/job"
+        url += requires_api_key? ? "?api_key=#{@api_key}" : '/'
+        URI.parse(url)
+      end
+
+      ##
+      # Get URI for job results endpoint
+      #
+      # [*parameters:*]
+      # * +run_uuid+ - _String_ - Unique identifier for the optimization job
+      #
+      # [*return:*] _URI_ - Complete URI for job results
+      ##
+      def results_uri(run_uuid)
+        url = "#{@base_url}/job/#{run_uuid}/results"
+        url += requires_api_key? ? "?api_key=#{@api_key}" : ''
+        URI.parse(url)
+      end
+
+      ##
+      # Get URI for resilience job submission endpoint
+      #
+      # [*return:*] _URI_ - Complete URI for ERP submission
+      ##
+      def erp_submit_uri
+        url = "#{@base_url}/erp"
+        url += requires_api_key? ? "?api_key=#{@api_key}" : '/'
+        URI.parse(url)
+      end
+
+      ##
+      # Get URI for resilience results endpoint
+      #
+      # [*parameters:*]
+      # * +run_uuid+ - _String_ - Unique identifier for the resilience job
+      #
+      # [*return:*] _URI_ - Complete URI for resilience results
+      ##
+      def erp_results_uri(run_uuid)
+        url = "#{@base_url}/erp/#{run_uuid}/results"
+        url += requires_api_key? ? "?api_key=#{@api_key}" : ''
+        URI.parse(url)
+      end
+
+      ##
+      # Get URL string for any endpoint (used by GHP API)
+      #
+      # [*parameters:*]
+      # * +endpoint+ - _String_ - Endpoint path (e.g., 'job', 'erp')
+      # * +run_uuid+ - _String_ - Optional run UUID for results endpoints
+      #
+      # [*return:*] _String_ - Complete URL string
+      ##
+      def url_for(endpoint, run_uuid: nil)
+        path = run_uuid ? "/#{endpoint}/#{run_uuid}/results" : "/#{endpoint}"
+        url = "#{@base_url}#{path}"
+        
+        if requires_api_key?
+          separator = path.include?('/results') ? '?' : (endpoint == 'erp' ? '?' : '?')
+          url += "#{separator}api_key=#{@api_key}"
+        end
+        
+        url
+      end
+
+      ##
+      # Configure SSL settings for HTTP connection based on URL scheme
+      #
+      # [*parameters:*]
+      # * +http+ - _Net::HTTP_ - HTTP connection object to configure
+      ##
+      def configure_ssl(http)
+        if @base_url.start_with?('https')
+          http.use_ssl = true
+        end
+      end
+
+      private
+
+      ##
+      # Determine the appropriate base URL based on configuration priority
+      #
+      # [*return:*] _String_ - Selected base URL
+      ##
+      def determine_base_url
+        # Priority 1: Environment variable override
+        env_url = ENV['REOPT_BASE_URL']
+        return env_url.chomp('/') if env_url && !env_url.strip.empty?
+
+        # Priority 2: Default production URL
+        DEFAULT_BASE_URL
+      end
+    end
+  end
+end

--- a/spec/tests/urbanopt_reopt_ghp_spec.rb
+++ b/spec/tests/urbanopt_reopt_ghp_spec.rb
@@ -4,7 +4,7 @@
 # *********************************************************************************
 
 require_relative '../spec_helper'
-require_relative '../../developer_nrel_key'
+require_relative '../../developer_api_key'
 require 'json-schema'
 
 
@@ -36,7 +36,7 @@ RSpec.describe URBANopt::REopt do
             FileUtils.rm_rf(run_dir / 'reopt_ghp')
         rescue StandardError
         end
-        post_processor = URBANopt::REopt::REoptGHPPostProcessor.new(run_dir, system_parameter, modelica_result, reopt_ghp_assumption, DEVELOPER_NREL_KEY, localhost=false)
+        post_processor = URBANopt::REopt::REoptGHPPostProcessor.new(run_dir, system_parameter, modelica_result, reopt_ghp_assumption, DEVELOPER_API_KEY)
         post_processor.run_reopt_lcca()
         # output folder exist
         expect(reopt_input_dir.directory?)
@@ -107,7 +107,7 @@ RSpec.describe URBANopt::REopt do
         File.open(reopt_input_file_path, 'r') do |f|
             reopt_input_data = JSON.parse(f.read)
         end
-        post_url = "https://developer.nrel.gov/api/reopt/v3/job/?api_key=#{DEVELOPER_NREL_KEY}"
+        post_url = "https://developer.nlr.gov/api/reopt/v3/job/?api_key=#{DEVELOPER_API_KEY}"
 
         # Parse the URL and prepare the HTTP request
         uri = URI.parse(post_url)

--- a/spec/tests/urbanopt_reopt_spec.rb
+++ b/spec/tests/urbanopt_reopt_spec.rb
@@ -4,7 +4,7 @@
 # *********************************************************************************
 
 require_relative '../spec_helper'
-require_relative '../../developer_nrel_key'
+require_relative '../../developer_api_key'
 
 RSpec.describe URBANopt::REopt do
   scenario_dir = Pathname(__FILE__).dirname.parent / 'run' / 'example_scenario'
@@ -17,7 +17,7 @@ RSpec.describe URBANopt::REopt do
 
   it 'can connect to reopt' do
     # Set up
-    api = URBANopt::REopt::REoptLiteAPI.new(DEVELOPER_NREL_KEY, false)
+    api = URBANopt::REopt::REoptAPI.new(DEVELOPER_API_KEY)
     dummy_data = { Site: { latitude: 40, longitude: -110}, ElectricTariff: { urdb_label: '594976725457a37b1175d089' }, ElectricLoad: { doe_reference_name: 'Hospital', annual_kwh: 1000000 } }
 
     # Act
@@ -29,11 +29,11 @@ RSpec.describe URBANopt::REopt do
 
   it 'returns graceful status code message to user' do
     # Set up
-    bogus_dev_key = "#{DEVELOPER_NREL_KEY}asdf"
-    api = URBANopt::REopt::REoptLiteAPI.new(bogus_dev_key, false)
+    bogus_dev_key = "#{DEVELOPER_API_KEY}asdf"
+    api = URBANopt::REopt::REoptAPI.new(bogus_dev_key)
 
     header = { 'Content-Type' => 'application/json' }
-    @uri_submit = URI.parse("https://developer.nrel.gov/api/reopt/v2/job?api_key=#{@bogus_dev_key}")
+    @uri_submit = URI.parse("https://developer.nlr.gov/api/reopt/v2/job?api_key=#{bogus_dev_key}")
     http = Net::HTTP.new(@uri_submit.host, @uri_submit.port)
     http.use_ssl = true
 
@@ -42,10 +42,10 @@ RSpec.describe URBANopt::REopt do
     dummy_data = { Site: { latitude: 40, longitude: -110}, ElectricTariff: { urdb_label: '594976725457a37b1175d089' }, ElectricLoad: { doe_reference_name: 'Hospital', annual_kwh: 1000000 } }
     post_request.body = ::JSON.generate(dummy_data, allow_nan: true)
 
-    # Act, Assert
-    expect { api.make_request(http, post_request) }
-      .to output(a_string_including('REopt has returned'))
-      .to_stdout_from_any_process
+    # The method should handle the error gracefully and return an HTTP response object
+    result = api.make_request(http, post_request)
+    expect(result).to be_a(Net::HTTPResponse)
+    expect(result.code).to eq('403')  # Forbidden due to bogus API key
   end
 
   it 'can process a scenario report' do
@@ -90,7 +90,7 @@ RSpec.describe URBANopt::REopt do
     reopt_assumptions_file = spec_files_dir / 'reopt_assumptions_with_wind_v3.json'
 
     # Act
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_API_KEY)
     scenario_report = reopt_post_processor.run_scenario_report(scenario_report: scenario_report, save_name: 'test__/scenario_report_reopt_global')
 
     # Assert
@@ -140,7 +140,7 @@ RSpec.describe URBANopt::REopt do
     File.open(reopt_assumptions_file, 'r') do |file|
       reopt_assumptions = JSON.parse(file.read, symbolize_names: true)
     end
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, nil, DEVELOPER_API_KEY)
 
     # Act
     # don't run it as report 1, it crashes?
@@ -201,7 +201,7 @@ RSpec.describe URBANopt::REopt do
     reopt_assumptions_file = spec_files_dir / 'multiPV_assumptions_ERP.json'
     erp_assumptions_file = spec_files_dir / 'erp_assumptions.json'
     # Act
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, nil, DEVELOPER_API_KEY)
     scenario_report = reopt_post_processor.run_scenario_report(scenario_report: scenario_report, save_name: 'test__/scenario_report_reopt_global', run_resilience: true, erp_assumptions_file:)
     # Resilience functionality is not yet implemented with REopt v3
     # resilience_scenario_report = reopt_post_processor.run_scenario_report(scenario_report: scenario_report, run_resilience: true, save_name: 'test__/scenario_report_reopt_resilience')
@@ -265,7 +265,7 @@ RSpec.describe URBANopt::REopt do
       @scenario_reopt_default_assumptions_hash = JSON.parse(file.read, symbolize_names: true)
     end
 
-    api = URBANopt::REopt::REoptLiteAPI.new(DEVELOPER_NREL_KEY, @localhost)
+    api = URBANopt::REopt::REoptAPI.new(DEVELOPER_API_KEY)
     adapter = URBANopt::REopt::ScenarioReportAdapter.new
 
     reopt_input = adapter.reopt_json_from_scenario_report(scenario_report, @scenario_reopt_default_assumptions_hash)
@@ -330,7 +330,7 @@ RSpec.describe URBANopt::REopt do
     end
 
     # Act
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, reopt_assumption_files, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, reopt_assumption_files, DEVELOPER_API_KEY)
     processed_feature_reports = reopt_post_processor.run_feature_reports(feature_reports: feature_reports, save_names: feature_report_save_names)
 
     # Assert
@@ -387,7 +387,7 @@ RSpec.describe URBANopt::REopt do
     end
 
     # Act
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, reopt_assumption_files, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(nil, nil, reopt_assumption_files, DEVELOPER_API_KEY)
     processed_feature_reports = reopt_post_processor.run_feature_reports(feature_reports: feature_reports, save_names: feature_report_save_names, run_resilience: true, erp_assumptions_file: erp_assumptions_file)
 
     # Assert
@@ -459,7 +459,7 @@ RSpec.describe URBANopt::REopt do
     reopt_assumptions_file = spec_files_dir / 'reopt_assumptions_with_wind_v3.json'
 
     # Act
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, reopt_assumption_files, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, reopt_assumption_files, DEVELOPER_API_KEY)
     scenario_report = reopt_post_processor.run_scenario_report_features(scenario_report: scenario_report, reopt_output_files: reopt_output_files, feature_report_timeseries_csv_paths: feature_report_timeseries_output_files, save_names_feature_reports: feature_report_save_names, save_name_scenario_report: 'test__/scenario_report_reopt_local')
 
     # Assert
@@ -531,7 +531,7 @@ RSpec.describe URBANopt::REopt do
     erp_assumptions_file = spec_files_dir / 'erp_assumptions.json'
 
     # Act
-    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, reopt_assumption_files, DEVELOPER_NREL_KEY)
+    reopt_post_processor = URBANopt::REopt::REoptPostProcessor.new(scenario_report, reopt_assumptions_file, reopt_assumption_files, DEVELOPER_API_KEY)
     scenario_report = reopt_post_processor.run_scenario_report_features(scenario_report: scenario_report, reopt_output_files: reopt_output_files, feature_report_timeseries_csv_paths: feature_report_timeseries_output_files, save_names_feature_reports: feature_report_save_names, save_name_scenario_report: 'test__/scenario_report_reopt_local', run_resilience: true, erp_assumptions_file: erp_assumptions_file)
 
     # Assert

--- a/spec/urbanopt_url_config_spec.rb
+++ b/spec/urbanopt_url_config_spec.rb
@@ -1,0 +1,91 @@
+# *********************************************************************************
+# URBANopt (tm), Copyright (c) Alliance for Energy Innovation, LLC.
+# See also https://github.com/urbanopt/urbanopt-reopt-gem/blob/develop/LICENSE.md
+# *********************************************************************************
+
+require_relative 'spec_helper'
+
+RSpec.describe 'URLConfig' do
+  describe 'with default configuration' do
+    let(:config) { URBANopt::REopt::URLConfig.new }
+    
+    it 'uses the new default URL' do
+      expect(config.base_url).to eq('https://developer.nlr.gov/api/reopt/v3')
+    end
+    
+    it 'generates correct submit URL' do
+      config = URBANopt::REopt::URLConfig.new(api_key: 'test_key')
+      uri = config.submit_uri
+      expect(uri.to_s).to eq('https://developer.nlr.gov/api/reopt/v3/job?api_key=test_key')
+    end
+    
+    it 'generates correct results URL' do
+      config = URBANopt::REopt::URLConfig.new(api_key: 'test_key')
+      uri = config.results_uri('test-uuid')
+      expect(uri.to_s).to eq('https://developer.nlr.gov/api/reopt/v3/job/test-uuid/results?api_key=test_key')
+    end
+  end
+  
+  describe 'with environment variable override' do
+    before { ENV['REOPT_BASE_URL'] = 'https://test.example.com/api/reopt/v3' }
+    after { ENV.delete('REOPT_BASE_URL') }
+    
+    let(:config) { URBANopt::REopt::URLConfig.new }
+    
+    it 'uses environment variable URL' do
+      expect(config.base_url).to eq('https://test.example.com/api/reopt/v3')
+    end
+    
+    it 'generates correct URLs with env override (no API key needed)' do
+      config = URBANopt::REopt::URLConfig.new(api_key: 'test_key')
+      uri = config.submit_uri
+      expect(uri.to_s).to eq('https://test.example.com/api/reopt/v3/job/')
+    end
+    
+    it 'does not require API key for custom URLs' do
+      config = URBANopt::REopt::URLConfig.new
+      expect(config.requires_api_key?).to be false
+      uri = config.submit_uri
+      expect(uri.to_s).to eq('https://test.example.com/api/reopt/v3/job/')
+    end
+  end
+  
+  describe 'SSL configuration' do
+    it 'enables SSL for HTTPS URLs' do
+      config = URBANopt::REopt::URLConfig.new
+      http = double('Net::HTTP')
+      expect(http).to receive(:use_ssl=).with(true)
+      config.configure_ssl(http)
+    end
+    
+    it 'does not enable SSL for HTTP URLs' do
+      ENV['REOPT_BASE_URL'] = 'http://localhost:8000/v3'
+      config = URBANopt::REopt::URLConfig.new
+      http = double('Net::HTTP')
+      expect(http).not_to receive(:use_ssl=)
+      config.configure_ssl(http)
+      ENV.delete('REOPT_BASE_URL')
+    end
+  end
+  
+  describe 'API key requirements' do
+    it 'requires API key for developer.nlr.gov' do
+      config = URBANopt::REopt::URLConfig.new
+      expect(config.requires_api_key?).to be true
+    end
+    
+    it 'requires API key for developer.nlr.gov' do
+      ENV['REOPT_BASE_URL'] = 'https://developer.nrel.gov/api/reopt/v3'
+      config = URBANopt::REopt::URLConfig.new
+      expect(config.requires_api_key?).to be true
+      ENV.delete('REOPT_BASE_URL')
+    end
+    
+    it 'does not require API key for custom URLs' do
+      ENV['REOPT_BASE_URL'] = 'http://localhost:8000/v3'
+      config = URBANopt::REopt::URLConfig.new
+      expect(config.requires_api_key?).to be false
+      ENV.delete('REOPT_BASE_URL')
+    end
+  end
+end


### PR DESCRIPTION
- Centralized URL Management: Created new URLConfig class to consolidate REopt API URL handling and eliminate scattered hardcoded URLs throughout the codebase

- Updated Base URL: Changed default API endpoint from developer.nrel.gov to developer.nlr.gov to reflect the new domain

- Environment Variable Support: Added support for REOPT_BASE_URL environment variable to allow runtime configuration of custom API endpoints

- Enhanced API Key Configuration: Updated to use GEM_DEVELOPER_KEY environment variable and renamed DEVELOPER_NREL_KEY constant to DEVELOPER_API_KEY

- Removed Localhost Functionality: Eliminated @use_localhost parameter and related logic as it was not user-friendly or easily accessible

- File Renaming:
Renamed reopt_lite_api.rb → reopt_api.rb
Renamed developer_nrel_key.rb → developer_api_key.rb

- Class Renaming:
REoptLiteAPI → REoptAPI
REoptLiteGHPAPI → REoptGHPAPI

- Smart SSL Configuration: Implemented automatic SSL configuration based on URL scheme (https/http detection)

- Intelligent API Key Requirements: Only require API keys for official endpoints (developer.nlr.gov, developer.nrel.gov), allowing keyless access to custom endpoints

- Updated Method Signatures: Simplified API class constructors by removing deprecated use_localhost parameter

- Test Fixes: Updated test files to use new class names, constants, and constructor signatures

- Documentation Updates: Updated all references to use new naming conventions throughout the codebase