### PR TITLE
Fixed sub-hourly timeseries shift ( issue #164) 

### DIFF
--- a/lib/urbanopt/reopt/feature_report_adapter.rb
+++ b/lib/urbanopt/reopt/feature_report_adapter.rb
@@ -453,12 +453,23 @@ module URBANopt # :nodoc:
 
         old_data = CSV.open(feature_report.timeseries_csv.path).read
         start_date = Time.parse(old_data[1][0])
-        start_ts = (
-                      (
-                        ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
-                        ((start_date.hour - 1) * 60.0 * 60.0) +
-                        (start_date.min * 60.0) + start_date.sec) / ((60 / feature_report.timesteps_per_hour) * 60)
-                    ).to_int
+        ## the commented part was causing aggregation error when running anything other than hourly (issue: 164) : hardcodes backing up by one hour which is wrong
+        #start_ts = (
+        #              (
+        #                ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
+        #                ((start_date.hour - 1) * 60.0 * 60.0) +
+        #                (start_date.min * 60.0) + start_date.sec) / ((60 / feature_report.timesteps_per_hour) * 60)
+        #            ).to_int
+
+        # bug fix : issue #164 
+        start_ts = reopt_timeseries_start_index(start_date, feature_report.timesteps_per_hour)
+        # start_ts = (
+        #               (
+        #                 ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
+        #                 (start_date.hour * 60.0 * 60.0) +
+        #                 (start_date.min * 60.0) + start_date.sec) / ((60 / feature_report.timesteps_per_hour) * 60)
+        #             ).to_int - 1
+
 
         mod_data = old_data.map.with_index do |x, i|
           if i > 0

--- a/lib/urbanopt/reopt/scenario_report_adapter.rb
+++ b/lib/urbanopt/reopt/scenario_report_adapter.rb
@@ -502,13 +502,25 @@ module URBANopt # :nodoc:
 
         old_data = CSV.open(scenario_report.timeseries_csv.path).read
         start_date = Time.parse(old_data[1][0]) # Time is the end of the timestep
-        start_ts = (
-                      (
-                        ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
-                        ((start_date.hour - 1) * 60.0 * 60.0) +
-                        (start_date.min * 60.0) + start_date.sec) / \
-                      ((60 / scenario_report.timesteps_per_hour) * 60)
-                    ).to_int
+        # bug in the commented snippet (issue #164) : hardcoded backing up by one hour > should be by the timestep
+        # start_ts = (
+        #               (
+        #                 ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
+        #                 ((start_date.hour - 1) * 60.0 * 60.0) +
+        #                 (start_date.min * 60.0) + start_date.sec) / \
+        #               ((60 / scenario_report.timesteps_per_hour) * 60)
+        #             ).to_int
+
+        # Bug fixed issue (#164) 
+        start_ts = reopt_timeseries_start_index(start_date, scenario_report.timesteps_per_hour)
+        # start_ts = (
+        #               (
+        #                 ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
+        #                 (start_date.hour * 60.0 * 60.0) +
+        #                 (start_date.min * 60.0) + start_date.sec) / \
+        #               ((60 / scenario_report.timesteps_per_hour) * 60)
+        #             ).to_int - 1
+
         mod_data = old_data.map.with_index do |x, i|
           if i > 0
             modrow(x, start_ts + i - 1)

--- a/lib/urbanopt/reopt/utilities.rb
+++ b/lib/urbanopt/reopt/utilities.rb
@@ -114,3 +114,20 @@ def convert_powerflow_resolution(timeseries_kw, original_res, destination_res)
   end
   return result
 end
+
+
+# bug fix (#164)
+# Start index into the full-year REopt array for the first CSV row. 
+# Timestamp is the interval END .... so back up one timestep (not by one hour) — fixes the sub-hourly shift.
+# This is applied in the feature and scenario adapters. 
+
+def reopt_timeseries_start_index(start_date, timesteps_per_hour)
+  seconds_per_timestep = (60 / timesteps_per_hour) * 60
+  (
+    (
+      ((start_date.yday - 1) * 60.0 * 60.0 * 24) +
+      (start_date.hour * 60.0 * 60.0) +
+      (start_date.min * 60.0) + start_date.sec
+    ) / seconds_per_timestep
+  ).to_int - 1
+end

--- a/spec/tests/urbanopt_reopt_spec.rb
+++ b/spec/tests/urbanopt_reopt_spec.rb
@@ -159,6 +159,18 @@ RSpec.describe URBANopt::REopt do
     FileUtils.rm_rf(scenario_dir / '1' / 'feature_reports')
   end
 
+
+
+  # All first-row stamps should map to index 0 regardless of resolution (The sub-hourly cases were off (-3 at 15-min, -1 at 30-min) before the fix).
+  it 'computes the REopt timeseries start index from end-of-interval timestamps' do
+    expect(reopt_timeseries_start_index(Time.new(2017, 1, 1, 1, 0, 0), 1)).to eq(0)
+    expect(reopt_timeseries_start_index(Time.new(2017, 1, 1, 0, 15, 0), 4)).to eq(0)
+    expect(reopt_timeseries_start_index(Time.new(2017, 1, 1, 0, 30, 0), 2)).to eq(0)
+    expect(reopt_timeseries_start_index(Time.new(2017, 1, 2, 0, 15, 0), 4)).to eq(96)
+  end
+
+
+  
   it 'can process a scenario erp report' do
     # Set up
     begin


### PR DESCRIPTION
start_ts backed up one hour instead of one timestep. Added shared reopt_timeseries_start_index helper (used in the fearture and scenario adapter).  Added a unit test.

### Resolves #[issue number here]

### Pull Request Description

[description here]

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
