### PR TITLE
Update error handling for ghp LCCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Version 1.1.0
 
-* Upgrade to OpenStudio 3.10 
+* Upgrade to OpenStudio 3.10
 
 ## Version 1.0.0
 

--- a/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
@@ -261,7 +261,7 @@ module URBANopt # :nodoc:
 
         end
 
-        #save output report in reopt_ghp directory
+        # save output report in reopt_ghp directory
         reopt_ghp_dir = File.join(run_dir, "reopt_ghp", "reopt_ghp_inputs")
         json_file_path = File.join(reopt_ghp_dir, "GHP_building_#{building_id}.json")
         pretty_json = JSON.pretty_generate(reopt_inputs_building)
@@ -333,38 +333,36 @@ module URBANopt # :nodoc:
 
 
         # Read GHX sizes from system parameter hash
-        ghe_specific_params = system_parameter_hash[:district_system][:fifth_generation][:ghe_parameters][:borefields]
+        ghe_specific_params = system_parameter_hash.dig(:district_system, :fifth_generation, :ghe_parameters, :borefields)
 
-        ghe_specific_params.each do |ghe|
-          if ghe[:ghe_id] == ghp_id
-            unless ghe[:pre_designed_borefield]
-              if ghe[:autosized_rectangle_borefield]
-                borefield = ghe[:autosized_rectangle_borefield]
+        # Keep valid defaults when borefield information is not provided.
+        ghpghx_output[:outputs][:number_of_boreholes] = 0
+        ghpghx_output[:outputs][:length_boreholes_ft] = 0
 
-              elsif ghe[:autosized_rectangle_constrained_borefield]
-                borefield = ghe[:autosized_rectangle_constrained_borefield]
+        if ghe_specific_params.nil? || ghe_specific_params.empty?
+          raise 'no borefields hash in the system parameters file. Make sure to first run the uo ghe_size command to size your GHE'
+        else
+          ghe = ghe_specific_params.find { |candidate| candidate[:ghe_id] == ghp_id }
 
-              elsif ghe[:autosized_birectangle_borefield]
-                borefield = ghe[:autosized_birectangle_borefield]
+          if ghe.nil?
+            raise "No borefield found with ghe_id '#{ghp_id}' in the system parameters file. Make sure your ghe_id matches one of the sized GHE entries from the uo ghe_size command"
+          else
+            borefield = ghe[:pre_designed_borefield] ||
+              ghe[:autosized_rectangle_borefield] ||
+              ghe[:autosized_rectangle_constrained_borefield] ||
+              ghe[:autosized_birectangle_borefield] ||
+              ghe[:autosized_birectangle_constrained_borefield] ||
+              ghe[:autosized_bizoned_rectangle_borefield] ||
+              ghe[:autosized_near_square_borefield] ||
+              ghe[:autosized_rowwise_borefield]
 
-              elsif ghe[:autosized_birectangle_constrained_borefield]
-                borefield = ghe[:autosized_birectangle_constrained_borefield]
-
-              elsif ghe[:autosized_bizoned_rectangle_borefield]
-                borefield = ghe[:autosized_bizoned_rectangle_borefield]
-
-              elsif ghe[:autosized_near_square_borefield]
-                borefield = ghe[:autosized_near_square_borefield]
-
-              elsif ghe[:autosized_rowwise_borefield]
-                borefield = ghe[:autosized_rowwise_borefield]
-              end
+            if borefield.nil?
+              raise 'no borefields hash in the system parameters file. Make sure to first run the uo ghe_size command to size your GHE'
+            else
+              ghpghx_output[:outputs][:number_of_boreholes] = borefield[:number_of_boreholes].to_i
+              # convert meters to feet by multiplying with 3.28084
+              ghpghx_output[:outputs][:length_boreholes_ft] = borefield[:borehole_length].to_f * 3.28084
             end
-
-            ghpghx_output[:outputs][:number_of_boreholes] = borefield[:number_of_boreholes]
-            # convert meters to feet by multiplying with 3.28084
-            ghpghx_output[:outputs][:length_boreholes_ft] = (borefield[:borehole_length])*3.28084
-
           end
         end
 

--- a/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
@@ -357,7 +357,7 @@ module URBANopt # :nodoc:
               ghe[:autosized_rowwise_borefield]
 
             if borefield.nil?
-              raise 'no borefields hash in the system parameters file. Make sure to first run the uo ghe_size command to size your GHE'
+              raise "No borefield sizing found for ghe_id '#{ghp_id}'. Expected one of: pre_designed_borefield, autosized_rectangle_borefield, autosized_rectangle_constrained_borefield, autosized_birectangle_borefield, autosized_birectangle_constrained_borefield, autosized_bizoned_rectangle_borefield, autosized_near_square_borefield, autosized_rowwise_borefield. Run `uo ghe_size` or provide a pre_designed_borefield."
             else
               ghpghx_output[:outputs][:number_of_boreholes] = borefield[:number_of_boreholes].to_i
               # convert meters to feet by multiplying with 3.28084

--- a/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
@@ -335,7 +335,7 @@ module URBANopt # :nodoc:
         # Read GHX sizes from system parameter hash
         ghe_specific_params = system_parameter_hash.dig(:district_system, :fifth_generation, :ghe_parameters, :borefields)
 
-        # Keep valid defaults when borefield information is not provided.
+        # Initialize outputs; validation below will raise if borefield sizing is missing.
         ghpghx_output[:outputs][:number_of_boreholes] = 0
         ghpghx_output[:outputs][:length_boreholes_ft] = 0
 

--- a/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_adapter_ghp.rb
@@ -340,7 +340,7 @@ module URBANopt # :nodoc:
         ghpghx_output[:outputs][:length_boreholes_ft] = 0
 
         if ghe_specific_params.nil? || ghe_specific_params.empty?
-          raise 'no borefields hash in the system parameters file. Make sure to first run the uo ghe_size command to size your GHE'
+          raise 'No borefields found at district_system.fifth_generation.ghe_parameters.borefields in the system parameters file. Run `uo ghe_size` to size your GHE before running this workflow.'
         else
           ghe = ghe_specific_params.find { |candidate| candidate[:ghe_id] == ghp_id }
 

--- a/lib/urbanopt/reopt/reopt_ghp_api.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_api.rb
@@ -53,7 +53,7 @@ module URBANopt # :nodoc:
             reopt_output_file = @reopt_output_file
 
             if run_id.nil?
-                run_id = get_run_uuid(reopt_input_file, api_key, reopt_output_file)
+                run_id = get_run_uuid
             end
             if !run_id.nil?
                 results_url = @url_config.url_for('job', run_uuid: run_id)
@@ -71,11 +71,7 @@ module URBANopt # :nodoc:
             results
         end
 
-        def get_run_uuid(reopt_input_file, api_key, root_url)
-
-            reopt_input_file = @reopt_input_file
-            api_key = @api_key
-            root_url = @root_url
+        def get_run_uuid
             post_url = @url_config.url_for('job')
             @@logger.info("Connecting to #{post_url}")
 
@@ -85,7 +81,7 @@ module URBANopt # :nodoc:
             request.content_type = 'application/json'
 
             # Add the JSON payload (assuming 'post' is the body data)
-            request.body = reopt_input_file.to_json
+            request.body = @reopt_input_file.to_json
 
             # Send the HTTP request
             response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|

--- a/lib/urbanopt/reopt/reopt_ghp_api.rb
+++ b/lib/urbanopt/reopt/reopt_ghp_api.rb
@@ -77,7 +77,6 @@ module URBANopt # :nodoc:
             api_key = @api_key
             root_url = @root_url
             post_url = @url_config.url_for('job')
-            puts "This is URL: #{post_url}"
             @@logger.info("Connecting to #{post_url}")
 
             # Parse the URL and prepare the HTTP request


### PR DESCRIPTION
### Pull Request Description

Improves error handling and code quality in the GHP LCCA workflow:

- **Borefield lookup**: Replaced direct hash access with `dig` for safer traversal of `district_system.fifth_generation.ghe_parameters.borefields`. Added explicit `nil`/empty checks with clear, actionable error messages pointing users to `uo ghe_size`.
- **Borefield matching**: Refactored the per-GHE loop to use `find` with early raises when no matching `ghe_id` is found or no recognized borefield sizing key is present.
- **Output initialization**: Initialized `number_of_boreholes` and `length_boreholes_ft` to `0` before the validation block so defaults are always set.
- **`get_run_uuid` method signature**: Removed misleading parameters (`reopt_input_file`, `api_key`, `root_url`) that were immediately overwritten with instance variables inside the method. The method now uses instance variables directly and takes no arguments; the call site in `get_api_results` was updated accordingly.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified appropriately
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-reopt-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop